### PR TITLE
WIP: Restore code from released version 0.0.38

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,15 @@ $ rufo --check file names or dir names
 ```
 
 This will print one line for each file that isn't correctly formatted
-according to **Rufo**, and will exit with exit code 1.
+according to **Rufo**, and will exit with exit code 3.
+
+### Exit codes
+
+| Code | Result |
+| ---- | ---- |
+| `0` | No errors, but also no formatting changes |
+| `1` | Error. Either `Ripper` could not parse syntax or input file is missing |
+| `3` | Input changed. Formatted code differs from input |
 
 ## Editor support
 
@@ -149,7 +157,7 @@ according to **Rufo**, and will exit with exit code 1.
 - Emacs [emacs-rufo](https://github.com/aleandros/emacs-rufo) :construction: or [rufo.el](https://github.com/danielma/rufo.el)
 - Sublime Text: [sublime-rufo](https://github.com/asterite/sublime-rufo)
 - Vim: [rufo-vim](https://github.com/splattael/rufo-vim)
-- Visual Studio Code: [rufo-vscode](https://marketplace.visualstudio.com/items?itemName=siliconsenthil.rufo-vscode)
+- Visual Studio Code: [rufo-vscode](https://marketplace.visualstudio.com/items?itemName=siliconsenthil.rufo-vscode) or [vscode-rufo](https://marketplace.visualstudio.com/items?itemName=mbessey.vscode-rufo)
 
 
 Did you write a plugin for your favorite editor? That's great! Let me know about it and

--- a/lib/rufo/command.rb
+++ b/lib/rufo/command.rb
@@ -3,6 +3,10 @@
 require "optparse"
 
 class Rufo::Command
+  CODE_OK = 0
+  CODE_ERROR = 1
+  CODE_CHANGE = 3
+
   def self.run(argv)
     want_check, filename_for_dot_rufo = parse_options(argv)
     new(want_check, filename_for_dot_rufo).run(argv)
@@ -15,25 +19,26 @@ class Rufo::Command
   end
 
   def run(argv)
-    if argv.empty?
-      format_stdin
-    else
-      format_args argv
-    end
+    status_code = if argv.empty?
+                    format_stdin
+                  else
+                    format_args argv
+                  end
+
+    exit status_code
   end
 
   def format_stdin
     code = STDIN.read
+
     result = format(code, @filename_for_dot_rufo || Dir.getwd)
 
-    if @want_check
-      exit 1 if result != code
-    else
-      print result
-    end
+    print(result) if !@want_check
+
+    code == result ? CODE_OK : CODE_CHANGE
   rescue Rufo::SyntaxError
     STDERR.puts "Error: the given text is not a valid ruby program (it has syntax errors)"
-    exit 1
+    CODE_ERROR
   rescue => ex
     STDERR.puts "You've found a bug!"
     STDERR.puts "Please report it to https://github.com/asterite/rufo/issues with code that triggers it"
@@ -54,13 +59,23 @@ class Rufo::Command
       end
     end
 
+    return CODE_ERROR if files.empty?
+
     changed = false
+    syntax_error = false
 
     files.each do |file|
-      changed |= format_file file
+      result = format_file(file)
+
+      changed |= result == CODE_CHANGE
+      syntax_error |= result == CODE_ERROR
     end
 
-    exit 1 if changed
+    case
+    when syntax_error then CODE_ERROR
+    when changed      then CODE_CHANGE
+    else                   CODE_OK
+    end
   end
 
   def format_file(filename)
@@ -72,24 +87,22 @@ class Rufo::Command
       # We ignore syntax errors as these might be template files
       # with .rb extension
       STDERR.puts "Error: #{filename} has syntax errors"
-      return true
+      return CODE_ERROR
     end
 
     if code.force_encoding(result.encoding) != result
       if @want_check
-        STDERR.puts "Error: formatting #{filename} produced changes"
+        STDERR.puts "Formatting #{filename} produced changes"
       else
         File.write(filename, result)
         puts "Format: #{filename}"
       end
 
-      return true
+      return CODE_CHANGE
     end
-
-    false
   rescue Rufo::SyntaxError
     STDERR.puts "Error: the given text in #{filename} is not a valid ruby program (it has syntax errors)"
-    exit 1
+    CODE_ERROR
   rescue => ex
     STDERR.puts "You've found a bug!"
     STDERR.puts "It happened while trying to format the file #{filename}"

--- a/lib/rufo/version.rb
+++ b/lib/rufo/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rufo
-  VERSION = "0.0.37"
+  VERSION = "0.0.38"
 end


### PR DESCRIPTION
I'd like to restore as much as possible from rufo's original code (including original SHAs!)

The current master of this repo only lacks of a few commits (2 or 3).

This PR restores the code from lastest release gem version 0.0.38:
See https://rubygems.org/gems/rufo/versions/0.0.38


**Please DO NOT merge it YET**

/cc @mjago @danielma @asterite 
