### PR TITLE
Fix squiggly heredoc leading space test

### DIFF
--- a/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
@@ -121,3 +121,28 @@ begin
      bar
   EOF
 end
+
+#~# ORIGINAL heredoc_squiggly_no_leading_space
+
+<<~EOF
+a
+EOF
+
+#~# EXPECTED
+
+<<~EOF
+  a
+EOF
+
+#~# ORIGINAL heredoc_squiggly_extra_spaces
+#~# PENDING
+
+<<~EOF
+#{1} #{2}
+EOF
+
+#~# EXPECTED
+
+<<~EOF
+#{1 }#{2}
+EOF

--- a/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
@@ -1,4 +1,4 @@
-#~# ORIGINAL 
+#~# ORIGINAL
 
 [
   [<<~'},'] # comment
@@ -12,7 +12,7 @@
   },
 ]
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 [
   [<<~'},'], # comment
@@ -26,7 +26,7 @@
   },
 ]
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 [
   [<<~'},'], # comment
@@ -42,7 +42,7 @@
   2,
 ]
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 [
   [<<~EOF] # comment
@@ -56,7 +56,7 @@
   EOF
 ]
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 begin
   foo = <<~STR
@@ -76,7 +76,7 @@ begin
   STR
 end
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 <<~EOF
   foo
@@ -90,7 +90,7 @@ EOF
    bar
 EOF
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 <<~EOF
   #{1}
@@ -104,9 +104,9 @@ EOF
    bar
 EOF
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
-begin 
+begin
  <<~EOF
   foo
    bar

--- a/spec/lib/rufo/formatter_source_specs/heredoc.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/heredoc.rb.spec
@@ -205,28 +205,3 @@ EOF
 text
 EOF
  2 => 3}
-
-#~# ORIGINAL heredoc_squiggly_no_leading_space
-
-<<~EOF
-a
-EOF
-
-#~# EXPECTED
-
-<<~EOF
-  a
-EOF
-
-#~# ORIGINAL heredoc_squiggly_extra_spaces
-#~# PENDING
-
-<<~EOF
-#{1} #{2}
-EOF
-
-#~# EXPECTED
-
-<<~EOF
-#{1 }#{2}
-EOF

--- a/spec/lib/rufo/formatter_source_specs/heredoc.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/heredoc.rb.spec
@@ -206,17 +206,16 @@ text
 EOF
  2 => 3}
 
-#~# ORIGINAL heredoc_squiggly
-#~# PENDING
+#~# ORIGINAL heredoc_squiggly_no_leading_space
 
 <<~EOF
- #{1}#{2}
+a
 EOF
 
 #~# EXPECTED
 
 <<~EOF
- #{1}#{2}
+  a
 EOF
 
 #~# ORIGINAL heredoc_squiggly_extra_spaces


### PR DESCRIPTION
After investigating the pending test it was identified that the test itself was incorrect. Squiggly heredoc strings are expected to be indented as all leading spaces are stripped. 

EDIT: Is this expectation correct?