### PR TITLE
Remove alignment config

### DIFF
--- a/.rufo
+++ b/.rufo
@@ -18,7 +18,6 @@ double_newline_inside_type  :no
 visibility_indent           :align
 trailing_commas             :always
 align_comments              true
-align_assignments           false
 align_hash_keys             false
 align_case_when             true
 align_chained_calls         true

--- a/.rufo
+++ b/.rufo
@@ -17,6 +17,5 @@ parens_in_def               :yes
 double_newline_inside_type  :no
 visibility_indent           :align
 trailing_commas             :always
-align_hash_keys             false
 align_case_when             true
 align_chained_calls         true

--- a/.rufo
+++ b/.rufo
@@ -17,7 +17,6 @@ parens_in_def               :yes
 double_newline_inside_type  :no
 visibility_indent           :align
 trailing_commas             :always
-align_comments              true
 align_hash_keys             false
 align_case_when             true
 align_chained_calls         true

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -796,9 +796,9 @@ class Rufo::Formatter
       end
     else
       want_space = first_space || @spaces_around_equal == :one
-      indent_after_space value, sticky: sticky,
-                                want_space: want_space,
-                                first_space: first_space,
+      indent_after_space value, sticky:              sticky,
+                                want_space:          want_space,
+                                first_space:         first_space,
                                 preserve_whitespace: @spaces_around_equal == :dynamic
     end
   end
@@ -1828,10 +1828,10 @@ class Rufo::Formatter
 
     if newline? || comment?
       indent_after_space right,
-                         want_space: needs_space,
-                         needed_indent: needed_indent,
-                         token_column: token_column,
-                         base_column: base_column,
+                         want_space:          needs_space,
+                         needed_indent:       needed_indent,
+                         token_column:        token_column,
+                         base_column:         base_column,
                          preserve_whitespace: @spaces_around_binary == :dynamic
     else
       if @spaces_around_binary == :one

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -169,7 +169,6 @@ class Rufo::Formatter
     indent_literals
     do_align_hash_keys if @align_hash_keys
     do_align_case_when if @align_case_when
-    do_align_comments if @align_comments
     remove_lines_before_inline_declarations
   end
 
@@ -3214,7 +3213,7 @@ class Rufo::Formatter
             # so append a space if needed (for example after an expression)
             unless at_prefix
               # Preserve whitespace before comment unless we need to align them
-              if last_space && !@align_comments
+              if last_space
                 write last_space[2]
               else
                 write_space
@@ -3784,10 +3783,6 @@ class Rufo::Formatter
     end
 
     @output = lines.join
-  end
-
-  def do_align_comments
-    do_align @comments_positions, :comment
   end
 
   def do_align_hash_keys

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -799,7 +799,7 @@ class Rufo::Formatter
       indent_after_space value, sticky: sticky,
                                 want_space: want_space,
                                 first_space: first_space,
-                                preserve_whitespace: @spaces_around_equal == :dynamic && !false
+                                preserve_whitespace: @spaces_around_equal == :dynamic
     end
   end
 

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -167,7 +167,6 @@ class Rufo::Formatter
 
     dedent_calls
     indent_literals
-    do_align_assignments if @align_assignments
     do_align_hash_keys if @align_hash_keys
     do_align_case_when if @align_case_when
     do_align_comments if @align_comments
@@ -724,7 +723,7 @@ class Rufo::Formatter
     line = @line
 
     visit target
-    consume_one_dynamic_space @spaces_around_equal, force_one: @align_assignments
+    consume_one_dynamic_space @spaces_around_equal, force_one: false
 
     track_assignment
     consume_op "="
@@ -742,7 +741,7 @@ class Rufo::Formatter
     line = @line
 
     visit target
-    consume_one_dynamic_space @spaces_around_equal, force_one: @align_assignments
+    consume_one_dynamic_space @spaces_around_equal, force_one: false
 
     # [:@op, "+=", [1, 2]],
     check :on_op
@@ -774,11 +773,7 @@ class Rufo::Formatter
       first_space = skip_space
     end
 
-    if @align_assignments
-      write_space
-    else
-      write_space_using_setting(first_space, @spaces_around_equal)
-    end
+    write_space_using_setting(first_space, @spaces_around_equal)
 
     track_assignment
     consume_op "="
@@ -805,7 +800,7 @@ class Rufo::Formatter
       indent_after_space value, sticky: sticky,
                                 want_space: want_space,
                                 first_space: first_space,
-                                preserve_whitespace: @spaces_around_equal == :dynamic && !@align_assignments
+                                preserve_whitespace: @spaces_around_equal == :dynamic && !false
     end
   end
 
@@ -3793,10 +3788,6 @@ class Rufo::Formatter
 
   def do_align_comments
     do_align @comments_positions, :comment
-  end
-
-  def do_align_assignments
-    do_align @assignments_positions, :assign
   end
 
   def do_align_hash_keys

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -167,7 +167,7 @@ class Rufo::Formatter
 
     dedent_calls
     indent_literals
-    do_align_hash_keys if @align_hash_keys
+    do_align_hash_keys
     do_align_case_when if @align_case_when
     remove_lines_before_inline_declarations
   end

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -722,7 +722,7 @@ class Rufo::Formatter
     line = @line
 
     visit target
-    consume_one_dynamic_space @spaces_around_equal, force_one: false
+    consume_one_dynamic_space @spaces_around_equal
 
     track_assignment
     consume_op "="
@@ -740,7 +740,7 @@ class Rufo::Formatter
     line = @line
 
     visit target
-    consume_one_dynamic_space @spaces_around_equal, force_one: false
+    consume_one_dynamic_space @spaces_around_equal
 
     # [:@op, "+=", [1, 2]],
     check :on_op
@@ -2255,7 +2255,7 @@ class Rufo::Formatter
     # or `"label": value`
     if arrow
       consume_op "=>"
-      consume_one_dynamic_space @spaces_around_hash_arrow, force_one: @align_hash_keys
+      consume_one_dynamic_space @spaces_around_hash_arrow
     end
 
     visit value
@@ -2954,8 +2954,8 @@ class Rufo::Formatter
     end
   end
 
-  def consume_one_dynamic_space(setting, force_one: false)
-    if setting == :one || force_one
+  def consume_one_dynamic_space(setting)
+    if setting == :one
       consume_space
     else
       if space?

--- a/lib/rufo/formatter/settings.rb
+++ b/lib/rufo/formatter/settings.rb
@@ -20,7 +20,6 @@ class Rufo::Formatter
     parens_in_def                options.fetch(:parens_in_def,                :dynamic)
     double_newline_inside_type   options.fetch(:double_newline_inside_type,   :dynamic)
     visibility_indent            options.fetch(:visibility_indent,            :dynamic)
-    align_hash_keys              options.fetch(:align_hash_keys,              false)
     align_case_when              options.fetch(:align_case_when,              false)
     align_chained_calls          options.fetch(:align_chained_calls,          false)
     trailing_commas              options.fetch(:trailing_commas,              :dynamic)
@@ -118,10 +117,6 @@ class Rufo::Formatter
     else
       raise ArgumentError.new("invalid value for visibility_indent: #{value}. Valid values are: :indent, :align, :dynamic")
     end
-  end
-
-  def align_hash_keys(value)
-    @align_hash_keys = value
   end
 
   def align_case_when(value)

--- a/lib/rufo/formatter/settings.rb
+++ b/lib/rufo/formatter/settings.rb
@@ -20,7 +20,6 @@ class Rufo::Formatter
     parens_in_def                options.fetch(:parens_in_def,                :dynamic)
     double_newline_inside_type   options.fetch(:double_newline_inside_type,   :dynamic)
     visibility_indent            options.fetch(:visibility_indent,            :dynamic)
-    align_comments               options.fetch(:align_comments,               false)
     align_hash_keys              options.fetch(:align_hash_keys,              false)
     align_case_when              options.fetch(:align_case_when,              false)
     align_chained_calls          options.fetch(:align_chained_calls,          false)
@@ -119,10 +118,6 @@ class Rufo::Formatter
     else
       raise ArgumentError.new("invalid value for visibility_indent: #{value}. Valid values are: :indent, :align, :dynamic")
     end
-  end
-
-  def align_comments(value)
-    @align_comments = value
   end
 
   def align_hash_keys(value)

--- a/lib/rufo/formatter/settings.rb
+++ b/lib/rufo/formatter/settings.rb
@@ -21,7 +21,6 @@ class Rufo::Formatter
     double_newline_inside_type   options.fetch(:double_newline_inside_type,   :dynamic)
     visibility_indent            options.fetch(:visibility_indent,            :dynamic)
     align_comments               options.fetch(:align_comments,               false)
-    align_assignments            options.fetch(:align_assignments,            false)
     align_hash_keys              options.fetch(:align_hash_keys,              false)
     align_case_when              options.fetch(:align_case_when,              false)
     align_chained_calls          options.fetch(:align_chained_calls,          false)
@@ -124,10 +123,6 @@ class Rufo::Formatter
 
   def align_comments(value)
     @align_comments = value
-  end
-
-  def align_assignments(value)
-    @align_assignments = value
   end
 
   def align_hash_keys(value)

--- a/spec/lib/rufo/formatter_source_specs/align_assignments.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/align_assignments.rb.spec
@@ -1,76 +1,70 @@
 #~# ORIGINAL
-#~# align_assignments: true
 
-x = 1 
+x = 1
  xyz = 2
 
  w = 3
 
 #~# EXPECTED
 
-x   = 1
+x = 1
 xyz = 2
 
 w = 3
 
 #~# ORIGINAL
-#~# align_assignments: true
 
-x = 1 
+x = 1
  foo[bar] = 2
 
  w = 3
 
 #~# EXPECTED
 
-x        = 1
+x = 1
 foo[bar] = 2
 
 w = 3
 
 #~# ORIGINAL
-#~# align_assignments: true
 
-x = 1; x = 2 
+x = 1; x = 2
  xyz = 2
 
  w = 3
 
 #~# EXPECTED
 
-x   = 1; x = 2
+x = 1; x = 2
 xyz = 2
 
 w = 3
 
 #~# ORIGINAL
-#~# align_assignments: true
 
 a = begin
- b = 1 
- abc = 2 
+ b = 1
+ abc = 2
  end
 
 #~# EXPECTED
 
 a = begin
-  b   = 1
+  b = 1
   abc = 2
 end
 
 #~# ORIGINAL
-#~# align_assignments: true
 
 a = 1
  a += 2
 
 #~# EXPECTED
 
-a  = 1
+a = 1
 a += 2
 
 #~# ORIGINAL
-#~# align_assignments: true
 
 foo = 1
  a += 2
@@ -78,12 +72,11 @@ foo = 1
 #~# EXPECTED
 
 foo = 1
-a  += 2
+a += 2
 
 #~# ORIGINAL
-#~# align_assignments: false
 
-x = 1 
+x = 1
  xyz = 2
 
  w = 3

--- a/spec/lib/rufo/formatter_source_specs/align_comments.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/align_comments.rb.spec
@@ -1,16 +1,14 @@
 #~# ORIGINAL
-#~# align_comments: true
 
 1 # one
  123 # two
 
 #~# EXPECTED
 
-1   # one
+1 # one
 123 # two
 
 #~# ORIGINAL
-#~# align_comments: true
 
 1 # one
  123 # two
@@ -19,13 +17,12 @@
 
 #~# EXPECTED
 
-1   # one
+1 # one
 123 # two
 4
 5 # lala
 
 #~# ORIGINAL
-#~# align_comments: true
 
 foobar( # one
  1 # two
@@ -34,22 +31,20 @@ foobar( # one
 #~# EXPECTED
 
 foobar( # one
-  1     # two
+  1 # two
 )
 
 #~# ORIGINAL
-#~# align_comments: true
 
 a = 1 # foo
  abc = 2 # bar
 
 #~# EXPECTED
 
-a = 1   # foo
+a = 1 # foo
 abc = 2 # bar
 
 #~# ORIGINAL
-#~# align_comments: true
 
 a = 1 # foo
       # bar
@@ -60,7 +55,6 @@ a = 1 # foo
       # bar
 
 #~# ORIGINAL
-#~# align_comments: true
 
 # foo
 a # bar
@@ -71,7 +65,6 @@ a # bar
 a # bar
 
 #~# ORIGINAL
-#~# align_comments: true
 
  # foo
 a # bar
@@ -82,7 +75,6 @@ a # bar
 a # bar
 
 #~# ORIGINAL
-#~# align_comments: true
 
 require x
 
@@ -99,7 +91,6 @@ require x
 FOO = :bar # Comment 3
 
 #~# ORIGINAL
-#~# align_comments: true
 
 begin
   require x
@@ -120,7 +111,6 @@ begin
 end
 
 #~# ORIGINAL
-#~# align_comments: true
 
 begin
   a     # c1
@@ -137,7 +127,6 @@ begin
 end
 
 #~# ORIGINAL
-#~# align_comments: false
 
 1 # one
  123 # two
@@ -148,7 +137,6 @@ end
 123 # two
 
 #~# ORIGINAL
-#~# align_comments: true
 
 foo bar( # foo
   1,     # bar
@@ -161,7 +149,6 @@ foo bar( # foo
 )
 
 #~# ORIGINAL
-#~# align_comments: false
 
 a = 1   # foo
 bar = 2 # baz
@@ -172,7 +159,6 @@ a = 1   # foo
 bar = 2 # baz
 
 #~# ORIGINAL
-#~# align_comments: false
 
 [
   1,   # foo
@@ -187,7 +173,6 @@ bar = 2 # baz
 ]
 
 #~# ORIGINAL
-#~# align_comments: false
 
 [
   1,   # foo
@@ -202,7 +187,6 @@ bar = 2 # baz
 ]
 
 #~# ORIGINAL
-#~# align_comments: false
 
 foo bar: 1,  # comment
     baz: 2    # comment

--- a/spec/lib/rufo/formatter_source_specs/align_comments.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/align_comments.rb.spec
@@ -1,7 +1,7 @@
 #~# ORIGINAL
 #~# align_comments: true
 
-1 # one 
+1 # one
  123 # two
 
 #~# EXPECTED
@@ -12,9 +12,9 @@
 #~# ORIGINAL
 #~# align_comments: true
 
-1 # one 
- 123 # two 
- 4 
+1 # one
+ 123 # two
+ 4
  5 # lala
 
 #~# EXPECTED
@@ -27,8 +27,8 @@
 #~# ORIGINAL
 #~# align_comments: true
 
-foobar( # one 
- 1 # two 
+foobar( # one
+ 1 # two
 )
 
 #~# EXPECTED
@@ -38,14 +38,14 @@ foobar( # one
 )
 
 #~# ORIGINAL
-#~# align_assignments: true, align_comments: true
+#~# align_comments: true
 
 a = 1 # foo
  abc = 2 # bar
 
 #~# EXPECTED
 
-a   = 1 # foo
+a = 1   # foo
 abc = 2 # bar
 
 #~# ORIGINAL

--- a/spec/lib/rufo/formatter_source_specs/align_hash_keys.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/align_hash_keys.rb.spec
@@ -1,8 +1,7 @@
 #~# ORIGINAL
-#~# align_hash_keys: true
 
-{ 
- 1 => 2, 
+{
+ 1 => 2,
  123 => 4 }
 
 #~# EXPECTED
@@ -13,10 +12,9 @@
 }
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
-{ 
- foo: 1, 
+{
+ foo: 1,
  barbaz: 2 }
 
 #~# EXPECTED
@@ -27,9 +25,8 @@
 }
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
-foo bar: 1, 
+foo bar: 1,
  barbaz: 2
 
 #~# EXPECTED
@@ -38,10 +35,9 @@ foo bar:    1,
     barbaz: 2
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
 foo(
-  bar: 1, 
+  bar: 1,
  barbaz: 2)
 
 #~# EXPECTED
@@ -52,10 +48,9 @@ foo(
 )
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
-def foo(x, 
- y: 1, 
+def foo(x,
+ y: 1,
  bar: 2)
 end
 
@@ -67,7 +62,6 @@ def foo(x,
 end
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
 {1 => 2}
 {123 => 4}
@@ -78,13 +72,12 @@ end
 {123 => 4}
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
 {
- 1 => 2, 
- 345 => { 
-  4 => 5 
- } 
+ 1 => 2,
+ 345 => {
+  4 => 5
+ }
  }
 
 #~# EXPECTED
@@ -97,13 +90,12 @@ end
 }
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
 {
- 1 => 2, 
- 345 => { # foo 
-  4 => 5 
- } 
+ 1 => 2,
+ 345 => { # foo
+  4 => 5
+ }
  }
 
 #~# EXPECTED
@@ -116,13 +108,12 @@ end
 }
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
 {
- 1 => 2, 
- 345 => [ 
-  4 
- ] 
+ 1 => 2,
+ 345 => [
+  4
+ ]
  }
 
 #~# EXPECTED
@@ -135,13 +126,12 @@ end
 }
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
 {
- 1 => 2, 
- foo: [ 
-  4 
- ] 
+ 1 => 2,
+ foo: [
+  4
+ ]
  }
 
 #~# EXPECTED
@@ -154,7 +144,6 @@ end
 }
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
 foo 1, bar: [
          2,
@@ -169,7 +158,6 @@ foo 1, bar: [
        baz: 3
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
 a   = b :foo => x,
   :baar => x
@@ -180,59 +168,53 @@ a   = b :foo  => x,
         :baar => x
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
  {:foo   =>   1 }
 
 #~# EXPECTED
 
-{:foo   => 1 }
+{:foo   =>   1 }
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
  {:foo   =>   1}
 
 #~# EXPECTED
 
-{:foo   => 1}
+{:foo   =>   1}
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
  { :foo   =>   1 }
 
 #~# EXPECTED
 
-{ :foo   => 1 }
+{ :foo   =>   1 }
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
  { :foo   =>   1 , 2  =>  3  }
 
 #~# EXPECTED
 
-{ :foo   => 1, 2  => 3  }
+{ :foo   =>   1, 2  =>  3  }
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
- { 
+ {
  :foo   =>   1 ,
  2  =>  3  }
 
 #~# EXPECTED
 
 {
-  :foo   => 1,
-  2      => 3
+  :foo   =>   1,
+  2      =>  3
 }
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
- { foo:  1, 
+ { foo:  1,
  bar: 2 }
 
 #~# EXPECTED
@@ -241,7 +223,6 @@ a   = b :foo  => x,
   bar:  2 }
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
 =begin
 =end
@@ -260,19 +241,17 @@ a   = b :foo  => x,
 }
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
 foo 1,  :bar  =>  2 , :baz  =>  3
 
 #~# EXPECTED
 
-foo 1,  :bar  => 2, :baz  => 3
+foo 1,  :bar  =>  2, :baz  =>  3
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
-{ 
- foo: 1, 
+{
+ foo: 1,
  barbaz: 2 }
 
 #~# EXPECTED

--- a/spec/lib/rufo/formatter_source_specs/align_mix.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/align_mix.rb.spec
@@ -1,5 +1,5 @@
 #~# ORIGINAL
-#~# align_assignments: true, align_hash_keys: true, align_comments: true
+#~# align_hash_keys: true, align_comments: true
 
 abc = 1
 a = {foo: 1, # comment
@@ -8,11 +8,11 @@ a = {foo: 1, # comment
 #~# EXPECTED
 
 abc = 1
-a   = {foo: 1, # comment
-       bar: 2} # another
+a = {foo: 1, # comment
+     bar: 2} # another
 
 #~# ORIGINAL
-#~# align_assignments: true, align_hash_keys: true, align_comments: true
+#~# align_hash_keys: true, align_comments: true
 
 abc = 1
 a = {foobar: 1, # comment
@@ -21,6 +21,6 @@ a = {foobar: 1, # comment
 #~# EXPECTED
 
 abc = 1
-a   = {foobar: 1, # comment
-       bar:    2} # another
+a = {foobar: 1, # comment
+     bar:    2} # another
 

--- a/spec/lib/rufo/formatter_source_specs/align_mix.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/align_mix.rb.spec
@@ -1,5 +1,4 @@
 #~# ORIGINAL
-#~# align_hash_keys: true
 
 abc = 1
 a = {foo: 1, # comment
@@ -12,7 +11,6 @@ a = {foo: 1, # comment
      bar: 2} # another
 
 #~# ORIGINAL
-#~# align_hash_keys: true
 
 abc = 1
 a = {foobar: 1, # comment

--- a/spec/lib/rufo/formatter_source_specs/align_mix.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/align_mix.rb.spec
@@ -1,5 +1,5 @@
 #~# ORIGINAL
-#~# align_hash_keys: true, align_comments: true
+#~# align_hash_keys: true
 
 abc = 1
 a = {foo: 1, # comment
@@ -12,7 +12,7 @@ a = {foo: 1, # comment
      bar: 2} # another
 
 #~# ORIGINAL
-#~# align_hash_keys: true, align_comments: true
+#~# align_hash_keys: true
 
 abc = 1
 a = {foobar: 1, # comment

--- a/spec/lib/rufo/formatter_source_specs/hash_literal.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/hash_literal.rb.spec
@@ -1,4 +1,4 @@
-#~# ORIGINAL 
+#~# ORIGINAL
 
  { }
 
@@ -6,7 +6,7 @@
 
 {}
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
  {:foo   =>   1 }
 
@@ -14,7 +14,7 @@
 
 {:foo   =>   1 }
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
  {:foo   =>   1}
 
@@ -22,7 +22,7 @@
 
 {:foo   =>   1}
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
  { :foo   =>   1 }
 
@@ -30,7 +30,7 @@
 
 { :foo   =>   1 }
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
  { :foo   =>   1 , 2  =>  3  }
 
@@ -38,9 +38,9 @@
 
 { :foo   =>   1, 2  =>  3  }
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- { 
+ {
  :foo   =>   1 ,
  2  =>  3  }
 
@@ -48,10 +48,10 @@
 
 {
   :foo   =>   1,
-  2  =>  3
+  2      =>  3
 }
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
  { **x }
 
@@ -59,7 +59,7 @@
 
 { **x }
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
  {foo:  1}
 
@@ -67,7 +67,7 @@
 
 {foo:  1}
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
  { foo:  1 }
 
@@ -75,50 +75,50 @@
 
 { foo:  1 }
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- { :foo   => 
+ { :foo   =>
   1 }
 
 #~# EXPECTED
 
-{ :foo   => 1 }
+{ :foo   =>  1 }
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- { "foo": 1 } 
+ { "foo": 1 }
 
 #~# EXPECTED
 
 { "foo": 1 }
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- { "foo #{ 2 }": 1 } 
+ { "foo #{ 2 }": 1 }
 
 #~# EXPECTED
 
 { "foo #{2}": 1 }
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- { :"one two"  => 3 } 
+ { :"one two"  => 3 }
 
 #~# EXPECTED
 
 { :"one two"  => 3 }
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- { foo:  1, 
- bar: 2 }
+ { foo:  1,
+   bar: 2 }
 
 #~# EXPECTED
 
 { foo:  1,
-  bar: 2 }
+  bar:  2 }
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 {foo: 1,  bar: 2}
 
@@ -126,7 +126,7 @@
 
 {foo: 1,  bar: 2}
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 {1 =>
    2}

--- a/spec/lib/rufo/formatter_source_specs/spaces_around_equal.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/spaces_around_equal.rb.spec
@@ -17,16 +17,16 @@ a  =  1
 a = 1
 
 #~# ORIGINAL
-#~# spaces_around_equal: :dynamic, align_assignments: true
+#~# spaces_around_equal: :dynamic
 
 a  =  1
 
 #~# EXPECTED
 
-a = 1
+a  =  1
 
 #~# ORIGINAL
-#~# spaces_around_equal: :one, align_assignments: true
+#~# spaces_around_equal: :one
 
 a  =  1
 
@@ -53,16 +53,16 @@ a  +=  1
 a += 1
 
 #~# ORIGINAL
-#~# spaces_around_equal: :dynamic, align_assignments: true
+#~# spaces_around_equal: :dynamic
 
 a  +=  1
 
 #~# EXPECTED
 
-a += 1
+a  +=  1
 
 #~# ORIGINAL
-#~# spaces_around_equal: :one, align_assignments: true
+#~# spaces_around_equal: :one
 
 a  +=  1
 


### PR DESCRIPTION
Started on the config changes discussed in #2.

This removes all the alignment config options related to alignment except `align_case_when`. There was no decision on this and I have never used that particular feature of ruby so not sure what it should be.

Each config option is removed in a separate commit to make it easier to review.

Let me know if you want to go in a different direction with this.