### PR TITLE
Add line length constrained printing utilities

### DIFF
--- a/lib/rufo.rb
+++ b/lib/rufo.rb
@@ -13,6 +13,8 @@ end
 require_relative "rufo/backport"
 require_relative "rufo/command"
 require_relative "rufo/dot_file"
+require_relative "rufo/doc_builder"
+require_relative "rufo/doc_printer"
 require_relative "rufo/formatter"
 require_relative "rufo/formatter/settings"
 require_relative "rufo/version"

--- a/lib/rufo/doc_builder.rb
+++ b/lib/rufo/doc_builder.rb
@@ -1,0 +1,123 @@
+module Rufo
+  class DocBuilder
+    class InvalidDocError < StandardError; end
+
+    class << self
+
+      # Combine an array of items into a single string.
+      def concat(parts)
+        assert_docs(parts)
+        {
+          type: :concat, parts: parts,
+        }
+      end
+
+      # Increase level of indentation.
+      def indent(contents)
+        assert_doc(contents)
+        {
+          type: :indent, contents: contents,
+        }
+      end
+
+      # Increase indentation by a fixed number.
+      def align(n, contents)
+        assert_doc(contents)
+        {type: :align, contents: contents, n: n}
+      end
+
+      # Groups are items that the printer should try and fit onto a single line.
+      # If the group does not fit then it breaks instead.
+      def group(contents, opts = {})
+        assert_doc(contents)
+        {
+          type: :group,
+          contents: contents,
+          break: !!opts[:should_break],
+          expanded_states: opts[:expanded_states],
+        }
+      end
+
+      # Rather than breaking if the items do not fit this tries a different set
+      # of items.
+      def conditional_group(states, opts = {})
+        group(states.first, opts.merge(expanded_states: states))
+      end
+
+      # Alternative to group. This only breaks the required items rather then
+      # all items if they do not fit.
+      def fill(parts)
+        assert_docs(parts)
+
+        {type: :fill, parts: parts}
+      end
+
+      # Print first arg if the group breaks otherwise print the second.
+      def if_break(break_contents, flat_contents)
+        assert_doc(break_contents) if break_contents.present?
+        assert_doc(flat_contents) if flat_contents.present?
+
+        {type: :if_break, break_contents: break_contents, flat_contents: flat_contents}
+      end
+
+      # Append content to the end of a line. This gets placed just before a new line.
+      def line_suffix(contents)
+        assert_doc(contents)
+        {type: :line_suffix, contents: contents}
+      end
+
+      # Join list of items with a separator.
+      def join(sep, arr)
+        result = []
+        arr.each_with_index do |element, index|
+          unless index == 0
+            result << sep
+          end
+          result << element
+        end
+        concat(result)
+      end
+
+      def add_alignment_to_doc(doc, size, tab_width)
+        return doc unless size > 0
+        (size/tab_width).times { doc = indent(doc) }
+        doc = align(size % tab_width, doc)
+        align(-Float::INFINITY, doc)
+      end
+
+      private
+
+      def assert_docs(parts)
+        parts.each(&method(:assert_doc))
+      end
+
+      def assert_doc(val)
+        unless val.is_a?(String) || (val.is_a?(Hash) && val[:type].is_a?(Symbol))
+          raise InvalidDocError.new("Value #{val.inspect} is not a valid document")
+        end
+      end
+    end
+
+    # Use this to ensure that line suffixes do not move to the last line in group.
+    LINE_SUFFIX_BOUNDARY = {type: :line_suffix_boundary}
+    # Use this to force the parent to break
+    BREAK_PARENT = {type: :break_parent}
+    # If the content fits on one line the newline will be replaced with a space.
+    # Newlines are what triggers indentation to be added.
+    LINE = {type: :line}
+    # If the content fits on one line the newline will be replaced by nothing.
+    SOFT_LINE = {type: :line, soft: true}
+    # This newline is always included regardless of if the content fits on one
+    # line or not.
+    HARD_LINE = concat([{type: :line, hard: true}, BREAK_PARENT])
+    # This is a newline that is always included and does not cause the
+    # indentation to change subsequently.
+    LITERAL_LINE = concat([
+      {type: :line, hard: true, literal: true},
+      BREAK_PARENT,
+    ])
+
+    # This keeps track of the cursor in the document.
+    CURSOR = {type: :cursor, placeholder: :cursor}
+  end
+end

--- a/lib/rufo/doc_builder.rb
+++ b/lib/rufo/doc_builder.rb
@@ -54,8 +54,8 @@ module Rufo
 
       # Print first arg if the group breaks otherwise print the second.
       def if_break(break_contents, flat_contents)
-        assert_doc(break_contents) if break_contents.present?
-        assert_doc(flat_contents) if flat_contents.present?
+        assert_doc(break_contents) unless break_contents.nil?
+        assert_doc(flat_contents) unless flat_contents.nil?
 
         {type: :if_break, break_contents: break_contents, flat_contents: flat_contents}
       end

--- a/lib/rufo/doc_printer.rb
+++ b/lib/rufo/doc_printer.rb
@@ -1,0 +1,289 @@
+module Rufo
+  class DocPrinter
+    ROOT_INDENT = {
+      indent: 0,
+      align: {
+        spaces: 0,
+      },
+    }
+    MODE_BREAK = 1
+    MODE_FLAT = 2
+    INDENT_WIDTH = 2
+    class << self
+      def print_doc_to_string(doc, opts)
+        width = opts.fetch(:print_width)
+        new_line = opts.fetch(:new_line, "\n")
+        pos = 0
+
+        cmds = [[ROOT_INDENT, MODE_BREAK, doc]]
+        out = []
+        should_remeasure = false
+        line_suffix = []
+
+        while cmds.length != 0
+          x = cmds.pop
+          puts x.inspect
+          ind = x[0]
+          mode = x[1]
+          doc = x[2]
+          if doc.is_a?(String)
+            out.push(doc)
+            pos += doc.length
+          else
+            puts doc.inspect
+            case doc[:type]
+            when :cursor
+              out.push(doc[:placeholder])
+            when :concat
+              doc[:parts].reverse_each { |part| cmds.push([ind, mode, part]) }
+            when :indent
+              cmds.push([make_indent(ind), mode, doc[:contents]])
+            when :align
+              cmds.push([make_align(ind, doc[:n]), mode, doc[:contents]])
+            when :group
+              if mode == MODE_FLAT && !should_remeasure
+                cmds.push([ind, doc[:break] ? MODE_BREAK : MODE_FLAT, doc[:contents]])
+                next
+              end
+              if mode == MODE_FLAT || mode == MODE_BREAK
+                should_remeasure = false
+                next_cmd = [ind, MODE_FLAT, doc[:contents]]
+                rem = width - pos
+
+                if !doc[:break] && fits(next_cmd, cmds, rem)
+                  cmds.push(next_cmd)
+                else
+                  unless doc[:expanded_states].nil?
+                    most_expanded = doc[:expanded_states].last
+
+                    if doc[:break]
+                      cmds.push([ind, MODE_BREAK, most_expanded])
+                      next
+                    else
+                      best_state = doc[:expanded_states].find { |state|
+                        state_cmd = [ind, MODE_FLAT, state]
+                        fits(state_cmd, cmds, rem)
+                      } || most_expanded
+                      cmds.push([ind, MODE_FLAT, best_state])
+                    end
+                  else
+                    cmds.push([ind, MODE_BREAK, doc[:contents]])
+                  end
+                end
+              end
+            when :fill
+              rem = width - pos
+              parts = doc[:parts]
+              next if parts.empty?
+
+              content = parts[0]
+              contents_flat_cmd = [ind, MODE_FLAT, content]
+              contents_break_cmd = [ind, MODE_BREAK, content]
+              content_fits = fits(contents_flat_cmd, [], width - rem, true)
+              if parts.length == 1
+                if content_fits
+                  cmds.push(contents_flat_cmd)
+                else
+                  cmds.push(contents_break_cmd)
+                end
+
+                next
+              end
+
+              whitespace = parts[1]
+              whitespace_flat_cmd = [ind, MODE_FLAT, whitespace]
+              whitespace_break_cmd = [ind, MODE_BREAK, whitespace]
+              if parts.length == 2
+                if content_fits
+                  cmds.push(whitespace_flat_cmd)
+                  cmds.push(contents_flat_cmd)
+                else
+                  cmds.push(whitespace_break_cmd)
+                  cmds.push(contents_break_cmd)
+                end
+                next
+              end
+
+              remaining = parts[2..-1]
+              remaining_cmd = [ind, mode, DocBuilder::fill(remaining)]
+
+              second_content = parts[2]
+              first_and_second_content_flat_cmd = [
+                ind, MODE_FLAT, DocBuilder::concat([content, whitespace, second_content]),
+              ]
+              first_and_second_content_fits = fits(
+                first_and_second_content_flat_cmd,
+                [],
+                rem,
+                true
+              )
+
+              if first_and_second_content_fits
+                cmds.push(remaining_cmd)
+                cmds.push(whitespace_flat_cmd)
+                cmds.push(contents_flat_cmd)
+              elsif content_fits
+                cmds.push(remaining_cmd)
+                cmds.push(whitespace_break_cmd)
+                cmds.push(contents_flat_cmd)
+              else
+                cmds.push(remaining_cmd)
+                cmds.push(whitespace_break_cmd)
+                cmds.push(contents_break_cmd)
+              end
+            when :if_break
+              if mode === MODE_BREAK
+                if doc[:break_contents]
+                  cmds.push([ind, mode, doc[:break_contents]])
+                end
+              end
+              if mode === MODE_FLAT
+                if doc[:flat_contents]
+                  cmds.push([ind, mode, doc[:flat_contents]])
+                end
+              end
+            when :line_suffix
+              line_suffix.push([ind, mode, doc[:contents]])
+            when :line_suffix_boundary
+              if line_suffix.length > 0
+                cmds.push([ind, mode, {type: :line, hard: true}])
+              end
+            when :line
+              if mode == MODE_FLAT
+                unless doc[:hard]
+                  unless doc[:soft]
+                    out.push(" ")
+                    pos += 1
+                  end
+                  next
+                else
+                  should_remeasure = true
+                end
+              end
+              if mode == MODE_FLAT || mode == MODE_BREAK
+                unless line_suffix.empty?
+                  cmds.push([ind, mode, doc])
+                  cmds.concat(line_suffix.reverse)
+                  line_suffix = []
+                  next
+                end
+
+                if doc[:literal]
+                  out.push(new_line)
+                  pos = 0
+                else
+                  if out.length > 0
+                    while out.length > 0 && out.last.match?(/^[^\S\n]*$/)
+                      out.pop
+                    end
+
+                    unless out.empty?
+                      out[-1] = out.last.sub(/[^\S\n]*$/, "")
+                    end
+                  end
+
+                  length = ind[:indent] * INDENT_WIDTH + ind[:align][:spaces]
+                  indent_string = " " * length
+                  out.push(new_line, indent_string)
+                  pos = length
+                end
+              end
+            end
+          end
+        end
+
+        cursor_place_holder_index = out.index(DocBuilder::CURSOR[:placeholder])
+
+        if cursor_place_holder_index
+          before_cursor = out[0..(cursor_place_holder_index-1)].join("")
+          after_cursor = out[(cursor_place_holder_index+1)..-1].join("")
+
+          return {
+                   formatted: before_cursor + after_cursor,
+                   cursor: before_cursor.length,
+                 }
+        end
+
+        {formatted: out.join("")}
+      end
+
+      private
+
+      def make_indent(ind)
+        {
+          indent: ind[:indent] + 1,
+          align: ind[:align],
+        }
+      end
+
+      def make_align(ind, n)
+        return ROOT_INDENT if n == -Float::INFINITY
+        {
+          indent: ind[:indent],
+          align: {
+            spaces: ind[:align][:spaces] + n,
+          },
+        }
+      end
+
+      def fits(next_cmd, rest_cmds, width, must_be_flat = false)
+        rest_idx = rest_cmds.size
+        cmds = [next_cmd]
+
+        while width >= 0
+          if cmds.size == 0
+            return true if (rest_idx == 0)
+            cmds.push(rest_cmds[rest_idx - 1])
+
+            rest_idx -= 1
+            next
+          end
+
+          x = cmds.pop
+          ind = x[0]
+          mode = x[1]
+          doc = x[2]
+
+          if doc.is_a?(String)
+            width -= doc.length
+          else
+            case doc[:type]
+            when :concat
+              doc[:parts].each { |part| cmds.push([ind, mode, part]) }
+            when :indent
+              cmds.push(make_indent(ind), mode, doc[:contents])
+            when :align
+              cmds.push([make_align(ind, doc[:n]), mode, doc[:contents]])
+            when :group
+              return false if must_be_flat && doc[:break]
+              cmds.push([ind, doc[:break] ? MODE_BREAK : mode, doc[:contents]])
+            when :fill
+              doc[:parts].each { |part| cmds.push([ind, mode, part]) }
+            when :if_break
+              if mode == MODE_BREAK && doc[:break_contents]
+                cmds.push([ind, mode, doc[:break_contents]])
+              elsif mode == MODE_FLAT && doc[:flat_contents]
+                cmds.push([ind, mode, doc[:flat_contents]])
+              end
+            when :line
+              case mode
+              when MODE_FLAT
+                unless doc[:hard]
+                  unless doc[:soft]
+                    width -= 1
+                  end
+                else
+                  return true
+                end
+              when MODE_BREAK
+                return true
+              end
+            end
+          end
+        end
+
+        return false
+      end
+    end
+  end
+end

--- a/lib/rufo/doc_printer.rb
+++ b/lib/rufo/doc_printer.rb
@@ -22,7 +22,6 @@ module Rufo
 
         while cmds.length != 0
           x = cmds.pop
-          puts x.inspect
           ind = x[0]
           mode = x[1]
           doc = x[2]
@@ -30,7 +29,6 @@ module Rufo
             out.push(doc)
             pos += doc.length
           else
-            puts doc.inspect
             case doc[:type]
             when :cursor
               out.push(doc[:placeholder])
@@ -173,7 +171,7 @@ module Rufo
                   pos = 0
                 else
                   if out.length > 0
-                    while out.length > 0 && out.last.match?(/^[^\S\n]*$/)
+                    while out.length > 0 && (out.last =~ /^[^\S\n]*$/)
                       out.pop
                     end
 

--- a/lib/rufo/doc_printer.rb
+++ b/lib/rufo/doc_printer.rb
@@ -249,7 +249,7 @@ module Rufo
             when :concat
               doc[:parts].each { |part| cmds.push([ind, mode, part]) }
             when :indent
-              cmds.push(make_indent(ind), mode, doc[:contents])
+              cmds.push([make_indent(ind), mode, doc[:contents]])
             when :align
               cmds.push([make_align(ind, doc[:n]), mode, doc[:contents]])
             when :group

--- a/spec/lib/rufo/doc_builder_spec.rb
+++ b/spec/lib/rufo/doc_builder_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe Rufo::DocBuilder do
+  it 'allows valid documents to be created' do
+    parts = ["something", {type: :symbol_yo}]
+    expect(described_class.concat(parts)).to eql({
+      type: :concat,
+      parts: parts,
+    })
+  end
+
+  it 'raises an error if a document is not the correct type' do
+    invalid_docs = [
+      [],
+      1,
+      {},
+      {type: "string"},
+    ]
+    invalid_docs.each do |doc|
+      expect { described_class.concat([doc]) }.to raise_error(
+        Rufo::DocBuilder::InvalidDocError
+      )
+    end
+  end
+end

--- a/spec/lib/rufo/doc_printer_spec.rb
+++ b/spec/lib/rufo/doc_printer_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+
+RSpec.describe Rufo::DocPrinter do
+  B = Rufo::DocBuilder
+
+  def print(doc, options = nil)
+    print_doc(doc, options)[:formatted]
+  end
+
+  def print_doc(doc, options = nil)
+    options ||= {}
+    options = {print_width: 80}.merge!(options)
+    described_class.print_doc_to_string(doc, options)
+  end
+
+  it 'prints concatenations' do
+    doc = B.concat(["a", " = ", "1"])
+    expect(print(doc)).to eql("a = 1")
+  end
+
+  it 'prints lines' do
+    doc = B.group(B.concat(["asd", B::LINE, "123"]))
+    expect(print(doc)).to eql("asd 123")
+    expect(print(doc, print_width: 4)).to eql("asd\n123")
+    expect(print(doc, print_width: 2)).to eql("asd\n123")
+  end
+
+  it 'prints soft lines' do
+    doc = B.group(B.concat(["asd", B::SOFT_LINE, "123"]))
+    expect(print(doc)).to eql("asd123")
+    expect(print(doc, print_width: 4)).to eql("asd\n123")
+  end
+
+  it 'prints hard lines' do
+    doc = B.group(B.concat(["asd", B::HARD_LINE, "123"]))
+    expect(print(doc)).to eql("asd\n123")
+    expect(print(doc, print_width: 4)).to eql("asd\n123")
+  end
+
+  it 'prints literal lines' do
+    doc = B.group(B.concat(["asd", B::LITERAL_LINE, "123"]))
+    expect(print(doc)).to eql("asd\n123")
+    expect(print(doc, print_width: 4)).to eql("asd\n123")
+  end
+
+  it 'prints indents' do
+    doc = B.indent(B.concat([B::HARD_LINE, "abc123"]))
+    expect(print(doc)).to eql("\n  abc123")
+  end
+
+  it 'does not print indents for literal lines' do
+    doc = B.indent(B.concat([B::LITERAL_LINE, "abc123"]))
+    expect(print(doc)).to eql("\nabc123")
+  end
+
+  it "prints alignments" do
+    doc = B.align(1, B.concat([B::HARD_LINE, "abc123"]))
+    expect(print(doc)).to eql("\n abc123")
+  end
+
+  describe "printing of groups" do
+    it 'prints simple groups' do
+      doc = B.group(B.concat(["asd", B::SOFT_LINE, "123"]))
+      expect(print(doc)).to eql('asd123')
+    end
+
+    it 'prints groups that should break' do
+      doc = B.group(B.concat(["asd", B::SOFT_LINE, "123"]), should_break: true)
+      expect(print(doc)).to eql("asd\n123")
+    end
+  end
+
+  it "prints conditional groups" do
+    doc_states = B.conditional_group([B.concat(["asd"]), B.concat(["as"])])
+    expect(print(doc_states)).to eql("asd")
+    expect(print(doc_states, print_width: 2)).to eql("as")
+  end
+
+  it "prints fill" do
+    doc = B.fill(["asd", B::LINE, "123", B::LINE, "qwe"])
+    expect(print(doc)).to eql("asd 123 qwe")
+    expect(print(doc, print_width: 8)).to eql("asd 123\nqwe")
+    expect(print(doc, print_width: 4)).to eql("asd\n123\nqwe")
+  end
+
+  it "prints line suffixes" do
+    doc = B.concat(["asd", B.line_suffix("qwe"), "123", B::HARD_LINE])
+    expect(print(doc)).to eql("asd123qwe\n")
+  end
+
+  it "prints joins" do
+    doc = B.join(", ", ["asd", "123"])
+    expect(print(doc)).to eql("asd, 123")
+  end
+
+  it "prints cursor positions" do
+    doc = B.concat(["asd", B::CURSOR, "123"])
+    expect(print_doc(doc)).to eql(formatted: "asd123", cursor: 3)
+  end
+end

--- a/spec/lib/rufo/doc_printer_spec.rb
+++ b/spec/lib/rufo/doc_printer_spec.rb
@@ -97,4 +97,47 @@ RSpec.describe Rufo::DocPrinter do
     doc = B.concat(["asd", B::CURSOR, "123"])
     expect(print_doc(doc)).to eql(formatted: "asd123", cursor: 3)
   end
+
+  context "array expression" do
+    let(:code_filled) {
+      <<~CODE.chomp("\n")
+        [1, 2, 3, 4, 5]
+      CODE
+    }
+    let(:code_broken) {
+      <<~CODE.chomp("\n")
+        [
+          1,
+          2,
+          3,
+          4,
+          5,
+        ]
+      CODE
+    }
+
+    let(:doc) {
+      B.group(
+        B.concat([
+          "[",
+          B.indent(
+            B.concat([
+              B::SOFT_LINE,
+              B.join(
+                B.concat([",", B::LINE]),
+                ["1", "2", "3", "4", B.concat(["5", B.if_break(",", "")])]
+              ),
+            ])
+          ),
+          B::SOFT_LINE,
+          "]",
+        ])
+      )
+    }
+
+    it 'formats correctly' do
+      expect(print(doc, print_width: 10)).to eql(code_broken)
+      expect(print(doc, print_width: 80)).to eql(code_filled)
+    end
+  end
 end


### PR DESCRIPTION
These utilities are based on the same utilities that power https://github.com/prettier/prettier and are those described in ["A prettier printer"](https://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf) by Philip Wadler.

I have largely just translated the code used by prettier and added tests for the individual document builder utilities.

Effectively this is introducing an intermediary representation that is agnostic to the actual language the code is written in. With these utilities the process of formatting a file would become something like the following: `ruby -> prettier_doc -> formatted_string`

I think that this intermediary format is valuable as it allows for other languages to be formatted as well. For example `html.erb` files.

Let me know if this is an approach that you are keen to pursue.