### PR TITLE
Change hash alignment

### DIFF
--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -167,7 +167,6 @@ class Rufo::Formatter
 
     dedent_calls
     indent_literals
-    do_align_hash_keys
     do_align_case_when if @align_case_when
     remove_lines_before_inline_declarations
   end

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -792,9 +792,9 @@ class Rufo::Formatter
       end
     else
       want_space = first_space || @spaces_around_equal == :one
-      indent_after_space value, sticky:              sticky,
-                                want_space:          want_space,
-                                first_space:         first_space,
+      indent_after_space value, sticky: sticky,
+                                want_space: want_space,
+                                first_space: first_space,
                                 preserve_whitespace: @spaces_around_equal == :dynamic
     end
   end
@@ -1818,10 +1818,10 @@ class Rufo::Formatter
 
     if newline? || comment?
       indent_after_space right,
-                         want_space:          needs_space,
-                         needed_indent:       needed_indent,
-                         token_column:        token_column,
-                         base_column:         base_column,
+                         want_space: needs_space,
+                         needed_indent: needed_indent,
+                         token_column: token_column,
+                         base_column: base_column,
                          preserve_whitespace: @spaces_around_binary == :dynamic
     else
       if @spaces_around_binary == :one

--- a/spec/lib/rufo/formatter_source_specs/align_hash_keys.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/align_hash_keys.rb.spec
@@ -7,7 +7,7 @@
 #~# EXPECTED
 
 {
-  1   => 2,
+  1 => 2,
   123 => 4
 }
 
@@ -20,7 +20,7 @@
 #~# EXPECTED
 
 {
-  foo:    1,
+  foo: 1,
   barbaz: 2
 }
 
@@ -31,7 +31,7 @@ foo bar: 1,
 
 #~# EXPECTED
 
-foo bar:    1,
+foo bar: 1,
     barbaz: 2
 
 #~# ORIGINAL
@@ -43,7 +43,7 @@ foo(
 #~# EXPECTED
 
 foo(
-  bar:    1,
+  bar: 1,
   barbaz: 2
 )
 
@@ -57,7 +57,7 @@ end
 #~# EXPECTED
 
 def foo(x,
-        y:   1,
+        y: 1,
         bar: 2)
 end
 
@@ -164,7 +164,7 @@ a   = b :foo => x,
 
 #~# EXPECTED
 
-a   = b :foo  => x,
+a   = b :foo => x,
         :baar => x
 
 #~# ORIGINAL
@@ -209,7 +209,7 @@ a   = b :foo  => x,
 
 {
   :foo   =>   1,
-  2      =>  3
+  2  =>  3
 }
 
 #~# ORIGINAL
@@ -220,7 +220,7 @@ a   = b :foo  => x,
 #~# EXPECTED
 
 { foo:  1,
-  bar:  2 }
+  bar: 2 }
 
 #~# ORIGINAL
 
@@ -257,7 +257,7 @@ foo 1,  :bar  =>  2, :baz  =>  3
 #~# EXPECTED
 
 {
-  foo:    1,
+  foo: 1,
   barbaz: 2
 }
 

--- a/spec/lib/rufo/formatter_source_specs/align_mix.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/align_mix.rb.spec
@@ -20,5 +20,5 @@ a = {foobar: 1, # comment
 
 abc = 1
 a = {foobar: 1, # comment
-     bar:    2} # another
+     bar: 2} # another
 

--- a/spec/lib/rufo/formatter_source_specs/hash_literal.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/hash_literal.rb.spec
@@ -48,7 +48,7 @@
 
 {
   :foo   =>   1,
-  2      =>  3
+  2  =>  3
 }
 
 #~# ORIGINAL
@@ -116,7 +116,7 @@
 #~# EXPECTED
 
 { foo:  1,
-  bar:  2 }
+  bar: 2 }
 
 #~# ORIGINAL
 


### PR DESCRIPTION
This removes the alignment of hashes so that they are never aligned.

This was discussed in #24 and @bessey suggested that not aligning hashes is the better choice. I believe the reasoning was:
- Aligning hashes increases diff noise, especially for large hashes.
- Aligning only really makes sense for hashes which have some commonality.