### PR TITLE
Swap squiggly heredoc tokens when ripper lexer emits out of sequence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.4.1
-  - 2.3.4
-  - 2.2.7
+  - 2.4.2
+  - 2.3.5
+  - 2.2.8
   - ruby-head
 before_install: gem install bundler -v 1.15.1
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ rvm:
   - 2.3.5
   - 2.2.8
   - ruby-head
-before_install: gem install bundler -v 1.15.1
+before_install: gem install bundler -v 1.15.4
 script:
   - bundle exec rake ci

--- a/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
@@ -94,14 +94,80 @@ EOF
 
 <<~EOF
   #{1}
+  #{2}
    bar
+   baz
 EOF
 
 #~# EXPECTED
 
 <<~EOF
   #{1}
+  #{2}
    bar
+   baz
+EOF
+
+#~# ORIGINAL
+
+<<~EOF
+  #{1}
+   #{2}
+   bar
+    baz
+EOF
+
+#~# EXPECTED
+
+<<~EOF
+  #{1}
+   #{2}
+   bar
+    baz
+EOF
+
+#~# ORIGINAL
+
+<<~EOF
+  #{1}
+  foo
+  #{2}
+  bar
+  #{3}
+  baz
+EOF
+
+#~# EXPECTED
+
+<<~EOF
+  #{1}
+  foo
+  #{2}
+  bar
+  #{3}
+  baz
+EOF
+
+#~# ORIGINAL
+
+<<~EOF
+  #{1}
+   foo
+  #{2}
+    bar
+  #{3}
+     baz
+EOF
+
+#~# EXPECTED
+
+<<~EOF
+  #{1}
+   foo
+  #{2}
+    bar
+  #{3}
+     baz
 EOF
 
 #~# ORIGINAL
@@ -135,7 +201,6 @@ EOF
 EOF
 
 #~# ORIGINAL heredoc_squiggly_extra_spaces
-#~# PENDING
 
 <<~EOF
 #{1} #{2}
@@ -144,5 +209,41 @@ EOF
 #~# EXPECTED
 
 <<~EOF
-#{1 }#{2}
+#{1} #{2}
+EOF
+
+#~# ORIGINAL heredoc_squiggly_extra_spaces_2
+
+<<~EOF
+  #{1}      #{2}
+EOF
+
+#~# EXPECTED
+
+<<~EOF
+  #{1}      #{2}
+EOF
+
+#~# ORIGINAL heredoc_squiggly_extra_spaces_3
+
+<<~EOF
+  #{1}#{2}
+EOF
+
+#~# EXPECTED
+
+<<~EOF
+  #{1}#{2}
+EOF
+
+#~# ORIGINAL heredoc_squiggly_extra_spaces_4
+
+<<~EOF
+ #{1}#{2}
+EOF
+
+#~# EXPECTED
+
+<<~EOF
+  #{1}#{2}
 EOF


### PR DESCRIPTION
Fix for #6 where ripper emits tokens out of sequence.

i.e.: ```ruby -rripper -rpp -e 'pp Ripper.lex("<<~EOF\n \#{1}\#{2}\nEOF")'```
gives:
```[[[1, 0], :on_heredoc_beg, "<<~EOF"],
 [[1, 6], :on_nl, "\n"],
 [[2, 1], :on_embexpr_beg, "\#{"],
 [[2, 1], :on_tstring_content, ""],
 [[2, 3], :on_int, "1"],
 [[2, 4], :on_embexpr_end, "}"],
 [[2, 5], :on_embexpr_beg, "\#{"],
 [[2, 7], :on_int, "2"],
 [[2, 8], :on_embexpr_end, "}"],
 [[2, 9], :on_tstring_content, "\n"],
 [[3, 0], :on_heredoc_end, "EOF"]]```