### PR TITLE
Advise user to upgrade where squiggly heredoc use detected.

### DIFF
--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -5,6 +5,8 @@ require "ripper"
 class Rufo::Formatter
   INDENT_SIZE = 2
 
+  attr_reader :squiggly_flag
+
   def self.format(code, **options)
     formatter = new(code, **options)
     formatter.format
@@ -12,6 +14,7 @@ class Rufo::Formatter
   end
 
   def initialize(code, **options)
+    @squiggly_flag = false
     @code = code
     @tokens = Ripper.lex(code).reverse!
     @sexp = Ripper.sexp(code)
@@ -226,7 +229,9 @@ class Rufo::Formatter
     when :@tstring_content
       # [:@tstring_content, "hello ", [1, 1]]
       heredoc, tilde = @current_heredoc
-
+      if heredoc && tilde && broken_ripper_version?
+        @squiggly_flag = true
+      end
       # For heredocs with tilde we sometimes need to align the contents
       if heredoc && tilde && @last_was_newline
         unless (current_token_value == "\n" ||
@@ -3729,6 +3734,12 @@ class Rufo::Formatter
     else
       Rufo::Backport.chunk_while(array, &block)
     end
+  end
+
+  def broken_ripper_version?
+    version, teeny = RUBY_VERSION[0..2], RUBY_VERSION[4..4].to_i
+    (version == "2.3" && teeny < 5) ||
+      (version == "2.4" && teeny < 2)
   end
 
   def remove_lines_before_inline_declarations

--- a/spec/lib/rufo/formatter_spec.rb
+++ b/spec/lib/rufo/formatter_spec.rb
@@ -89,4 +89,42 @@ RSpec.describe Rufo::Formatter do
     assert_format "\n\n", ""
     assert_format "\n\n\n", ""
   end
+
+  describe "Ensure broken Ripper versions detected" do
+    it "ensures broken_ripper_version? returns true for broken Ruby versions" do
+      fmtr = Rufo::Formatter.new("")
+      ["2.3.0", "2.3.1", "2.3.2", "2.3.3", "2.3.4", "2.4.0", "2.4.1"].each do |version|
+        stub_const("RUBY_VERSION", version)
+        expect(fmtr.broken_ripper_version?).to eq(true)
+      end
+    end
+
+    it "ensures broken_ripper_version? returns false for fixed Ruby versions" do
+      fmtr = Rufo::Formatter.new("")
+      ["2.3.5", "2.4.2"].each do |version|
+        stub_const("RUBY_VERSION", version)
+        expect(fmtr.broken_ripper_version?).to eq(false)
+      end
+    end
+
+    it "checks current recommended Ruby 2.3 is relevant" do
+      expect(RUBY_VERSION).to eq("2.3.5") if RUBY_VERSION[0..2] == "2.3"
+    end
+
+    it "checks current recommended Ruby 2.4 is relevant" do
+      expect(RUBY_VERSION).to eq("2.4.2") if RUBY_VERSION[0..2] == "2.4"
+    end
+
+    it "checks backported Ruby 2.3 is relevant" do
+      if RUBY_VERSION[0..2] == "2.3"
+        expect(Rufo::Command.new(false, '').backported_version).to eq("2.3.5")
+      end
+    end
+
+    it "checks backported Ruby 2.4 is relevant" do
+      if RUBY_VERSION[0..2] == "2.4"
+        expect(Rufo::Command.new(false, '').backported_version).to eq("2.4.2")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Also avoid formatting files containing squiggly heredoc on
broken Ripper versions of Ruby.