### PR TITLE
Remove spaces in hash config

### DIFF
--- a/.rufo
+++ b/.rufo
@@ -1,4 +1,3 @@
-spaces_inside_hash_brace    :never
 spaces_around_binary        :one
 double_newline_inside_type  :no
 trailing_commas             :always

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -2563,12 +2563,7 @@ class Rufo::Formatter
     first_space = skip_space
 
     if inside_hash
-      case @spaces_inside_hash_brace
-      when :never
-        needs_final_space = false
-      when :always
-        needs_final_space = true
-      end
+      needs_final_space = false
     end
 
     if inside_array
@@ -2577,13 +2572,6 @@ class Rufo::Formatter
 
     if newline? || comment?
       needs_final_space = false
-    elsif needs_final_space
-      if inside_hash && first_space && @spaces_inside_hash_brace == :dynamic
-        write first_space[2]
-      else
-        consume_space
-      end
-      base_column = @column
     end
 
     # If there's a newline right at the beginning,
@@ -2619,16 +2607,6 @@ class Rufo::Formatter
       # because we miss the chance to write a comma to separate elements
       first_space = skip_space_no_heredoc_check
       wrote_comma = check_heredocs_in_literal_elements(is_last, needs_trailing_comma, wrote_comma)
-
-      if is_last && !comma? && !wrote_comma && !needs_trailing_comma && !comment?
-        if (inside_hash && @spaces_inside_hash_brace == :dynamic)
-          if first_space
-            write first_space[2]
-          else
-            needs_final_space = false
-          end
-        end
-      end
 
       next unless comma?
 

--- a/lib/rufo/formatter/settings.rb
+++ b/lib/rufo/formatter/settings.rb
@@ -1,16 +1,11 @@
 class Rufo::Formatter
   def init_settings(options)
-    spaces_inside_hash_brace options.fetch(:spaces_inside_hash_brace, :never)
     spaces_around_binary options.fetch(:spaces_around_binary, :dynamic)
     parens_in_def options.fetch(:parens_in_def, :yes)
     double_newline_inside_type options.fetch(:double_newline_inside_type, :dynamic)
     align_case_when options.fetch(:align_case_when, false)
     align_chained_calls options.fetch(:align_chained_calls, false)
     trailing_commas options.fetch(:trailing_commas, :always)
-  end
-
-  def spaces_inside_hash_brace(value)
-    @spaces_inside_hash_brace = dynamic_always_never_match("spaces_inside_hash_brace", value)
   end
 
   def spaces_around_binary(value)

--- a/lib/rufo/formatter/settings.rb
+++ b/lib/rufo/formatter/settings.rb
@@ -1,6 +1,6 @@
 class Rufo::Formatter
   def init_settings(options)
-    spaces_inside_hash_brace options.fetch(:spaces_inside_hash_brace, :dynamic)
+    spaces_inside_hash_brace options.fetch(:spaces_inside_hash_brace, :never)
     spaces_around_binary options.fetch(:spaces_around_binary, :dynamic)
     parens_in_def options.fetch(:parens_in_def, :yes)
     double_newline_inside_type options.fetch(:double_newline_inside_type, :dynamic)

--- a/spec/lib/rufo/formatter_source_specs/align_hash_keys.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/align_hash_keys.rb.spec
@@ -173,7 +173,7 @@ a = b :foo => x,
 
 #~# EXPECTED
 
-{:foo => 1 }
+{:foo => 1}
 
 #~# ORIGINAL
 
@@ -189,7 +189,7 @@ a = b :foo => x,
 
 #~# EXPECTED
 
-{ :foo => 1 }
+{:foo => 1}
 
 #~# ORIGINAL
 
@@ -197,7 +197,7 @@ a = b :foo => x,
 
 #~# EXPECTED
 
-{ :foo => 1, 2 => 3  }
+{:foo => 1, 2 => 3}
 
 #~# ORIGINAL
 
@@ -219,8 +219,8 @@ a = b :foo => x,
 
 #~# EXPECTED
 
-{ foo: 1,
-  bar: 2 }
+{foo: 1,
+ bar: 2}
 
 #~# ORIGINAL
 

--- a/spec/lib/rufo/formatter_source_specs/hash_literal.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/hash_literal.rb.spec
@@ -12,7 +12,7 @@
 
 #~# EXPECTED
 
-{:foo => 1 }
+{:foo => 1}
 
 #~# ORIGINAL
 
@@ -28,7 +28,7 @@
 
 #~# EXPECTED
 
-{ :foo => 1 }
+{:foo => 1}
 
 #~# ORIGINAL
 
@@ -36,7 +36,7 @@
 
 #~# EXPECTED
 
-{ :foo => 1, 2 => 3  }
+{:foo => 1, 2 => 3}
 
 #~# ORIGINAL
 
@@ -57,7 +57,7 @@
 
 #~# EXPECTED
 
-{ **x }
+{**x}
 
 #~# ORIGINAL
 
@@ -73,7 +73,7 @@
 
 #~# EXPECTED
 
-{ foo: 1 }
+{foo: 1}
 
 #~# ORIGINAL
 
@@ -82,7 +82,7 @@
 
 #~# EXPECTED
 
-{ :foo => 1 }
+{:foo => 1}
 
 #~# ORIGINAL
 
@@ -90,7 +90,7 @@
 
 #~# EXPECTED
 
-{ "foo": 1 }
+{"foo": 1}
 
 #~# ORIGINAL
 
@@ -98,7 +98,7 @@
 
 #~# EXPECTED
 
-{ "foo #{2}": 1 }
+{"foo #{2}": 1}
 
 #~# ORIGINAL
 
@@ -106,7 +106,7 @@
 
 #~# EXPECTED
 
-{ :"one two" => 3 }
+{:"one two" => 3}
 
 #~# ORIGINAL
 
@@ -115,8 +115,8 @@
 
 #~# EXPECTED
 
-{ foo: 1,
-  bar: 2 }
+{foo: 1,
+ bar: 2}
 
 #~# ORIGINAL
 

--- a/spec/lib/rufo/formatter_source_specs/spaces_inside_hash_brace.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/spaces_inside_hash_brace.rb.spec
@@ -1,54 +1,8 @@
 #~# ORIGINAL
-#~# spaces_inside_hash_brace: :never
 
 { 1 => 2 }
 
 #~# EXPECTED
 
 {1 => 2}
-
-#~# ORIGINAL
-#~# spaces_inside_hash_brace: :always
-
-{1 => 2}
-
-#~# EXPECTED
-
-{ 1 => 2 }
-
-#~# ORIGINAL
-#~# spaces_inside_hash_brace: :dynamic
-
-{  1 => 2   }
-
-#~# EXPECTED
-
-{  1 => 2   }
-
-#~# ORIGINAL
-#~# spaces_inside_hash_brace: :match
-
-{1 => 2  }
-
-#~# EXPECTED
-
-{1 => 2}
-
-#~# ORIGINAL
-#~# spaces_inside_hash_brace: :match
-
-{  1 => 2}
-
-#~# EXPECTED
-
-{ 1 => 2 }
-
-#~# ORIGINAL
-#~# spaces_inside_hash_brace: :match
-
-{  1 => 2   }
-
-#~# EXPECTED
-
-{ 1 => 2 }
 


### PR DESCRIPTION
This changes the `spaces_inside_hash_brace` to never and removes the ability to configure it as part of #2.