### PR TITLE
Add --no-exit-code option (-x)

### DIFF
--- a/lib/rufo/command.rb
+++ b/lib/rufo/command.rb
@@ -8,15 +8,29 @@ class Rufo::Command
   CODE_CHANGE = 3
 
   def self.run(argv)
-    want_check, filename_for_dot_rufo = parse_options(argv)
-    new(want_check, filename_for_dot_rufo).run(argv)
+    want_check, exit_code, filename_for_dot_rufo = parse_options(argv)
+    new(want_check, exit_code, filename_for_dot_rufo).run(argv)
   end
 
-  def initialize(want_check, filename_for_dot_rufo)
+  def initialize(want_check, exit_code, filename_for_dot_rufo)
     @want_check = want_check
+    @exit_code = exit_code
     @filename_for_dot_rufo = filename_for_dot_rufo
     @dot_file = Rufo::DotFile.new
     @squiggly_warning_files = []
+  end
+
+  def exit_code(status_code)
+    if @exit_code
+      status_code
+    else
+      case status_code
+      when CODE_OK, CODE_CHANGE
+        0
+      else
+        1
+      end
+    end
   end
 
   def run(argv)
@@ -25,8 +39,7 @@ class Rufo::Command
                   else
                     format_args argv
                   end
-
-    exit status_code
+    exit exit_code(status_code)
   end
 
   def format_stdin
@@ -161,7 +174,7 @@ Rufo Warning!
   end
 
   def self.parse_options(argv)
-    want_check = false
+    exit_code, want_check = true, false
     filename_for_dot_rufo = nil
 
     OptionParser.new do |opts|
@@ -176,12 +189,16 @@ Rufo Warning!
         filename_for_dot_rufo = value
       end
 
+      opts.on("-x", "--simple-exit", "Return 1 in the case of failure, else 0") do
+        exit_code = false
+      end
+
       opts.on("-h", "--help", "Show this help") do
         puts opts
         exit
       end
     end.parse!(argv)
 
-    [want_check, filename_for_dot_rufo]
+    [want_check, exit_code, filename_for_dot_rufo]
   end
 end

--- a/spec/lib/rufo/formatter_spec.rb
+++ b/spec/lib/rufo/formatter_spec.rb
@@ -117,13 +117,13 @@ RSpec.describe Rufo::Formatter do
 
     it "checks backported Ruby 2.3 is relevant" do
       if RUBY_VERSION[0..2] == "2.3"
-        expect(Rufo::Command.new(false, '').backported_version).to eq("2.3.5")
+        expect(Rufo::Command.new(false, true, '').backported_version).to eq("2.3.5")
       end
     end
 
     it "checks backported Ruby 2.4 is relevant" do
       if RUBY_VERSION[0..2] == "2.4"
-        expect(Rufo::Command.new(false, '').backported_version).to eq("2.4.2")
+        expect(Rufo::Command.new(false, true, '').backported_version).to eq("2.4.2")
       end
     end
   end


### PR DESCRIPTION
Add command line option to provide unix conventional status code
output: 0 no error, 1 error

This covers the case where CI systems or plugins just require a non-zero value on error, 
0 on success, and don't require to know whether formatting actually took place.

This will enable us to answer issues regarding status code returned with `just pass flag -x'