### PR TITLE
Add failing test for bug from ruby/spec

### DIFF
--- a/spec/lib/rufo/formatter_source_specs/for.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/for.rb.spec
@@ -1,7 +1,7 @@
-#~# ORIGINAL 
+#~# ORIGINAL
 
 for  x  in  y
- 2 
+ 2
  end
 
 #~# EXPECTED
@@ -10,10 +10,10 @@ for x in y
   2
 end
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 for  x , y  in  z
- 2 
+ 2
  end
 
 #~# EXPECTED
@@ -22,14 +22,27 @@ for x, y in z
   2
 end
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 for  x  in  y  do
- 2 
+ 2
  end
 
 #~# EXPECTED
 
 for x in y
   2
+end
+
+#~# ORIGINAL
+#~# PENDING
+
+for i, in [[1,2]]
+  i.should == 1
+end
+
+#~# EXPECTED
+
+for i, in [[1,2]]
+  i.should == 1
 end


### PR DESCRIPTION
Wanted to see how  #41 fared on the ruby/spec codebase and ran into this issue:

```
Rufo::Bug:
       Expected token on_kw, not on_comma at [[2, 5], :on_comma, ","]
```

The problematic code can be [here](
https://github.com/ruby/spec/blob/847d901c433fe4fcf2137e908b18ec02e80c80df/language/for_spec.rb#L16).