### PR TITLE
Restructure and partially rewrite the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,44 @@
 
 **Ru**by **fo**rmatter
 
-## Why
 
-Rufo's primary use case is as a text-editor plugin, to autoformat files on save or
-on demand. For this reason it needs to be fast. If the formatter is slow, saving
-a file becomes painful.
+Rufo is as an _opinionated_ ruby formatter, intended to be used via the command line as a text-editor plugin, to autoformat files on save or on demand.
 
-Right now, Rufo can format it's [formatter](https://github.com/ruby-formatter/rufo/blob/master/lib/rufo/formatter.rb),
-a 3000+ lines file, in about 290ms. It can format a ~500 lines file in 180ms. Since most files
-have less than 500 lines, the time is acceptable.
+Unlike the best known Ruby formatter [RuboCop](https://github.com/bbatsov/rubocop), Rufo offers little in the way of configuration. Like other language formatters such as [gofmt](https://golang.org/cmd/gofmt/), [prettier](https://github.com/prettier/prettier), and [autopep8](https://github.com/hhatto/autopep8), we strive to find a "one true format" for Ruby code, and make sure your code adheres to it, with zero config where possible.
 
-There's at least one other good Ruby formatter I know: [RuboCop](https://github.com/bbatsov/rubocop).
-However, it takes between 2 and 5 seconds to format a 3000+ lines file, and about 1 second to format
-a 500 lines file. A second is too much delay for a plugin editor. Additionally, RuboCop is much more
-than just a code formatter. Rufo is and will always be a code formatter.
+RuboCop does much more than just format code though, so feel free to run them both!
+
+Rufo supports all Ruby versions >= 2.2.4, but works most reliably with >= 2.3.**5** / >= 2.4.**2**, due to a bug in Ruby's Ripper parser.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'rufo'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it system wide with:
+
+    $ gem install rufo
+
+## Editor support
+
+Once the gem is installed, enable format on save integration in your editor of choice with the following libraries:
+
+- Atom: [rufo-atom](https://github.com/bmulvihill/rufo-atom) :construction:
+- Emacs [emacs-rufo](https://github.com/aleandros/emacs-rufo) :construction: or [rufo.el](https://github.com/danielma/rufo.el)
+- Sublime Text: [sublime-rufo](https://github.com/ruby-formatter/sublime-rufo)
+- Vim: [rufo-vim](https://github.com/splattael/rufo-vim)
+- Visual Studio Code: [vscode-rufo](https://marketplace.visualstudio.com/items?itemName=mbessey.vscode-rufo) or [rufo-vscode](https://marketplace.visualstudio.com/items?itemName=siliconsenthil.rufo-vscode)
+
+If you're interested in developing your own plugin check out the [development docs](docs/developing-rufo.md). Did you already write a plugin? That's great! Let us know about it and
+we will list it here.
+
 
 ## Unobtrusive by default
 
@@ -48,7 +72,7 @@ register :action,  "Save"
 ```
 
 Here too, an extra space is added to align `"Format"` with `"Save"`. Again, Rufo will preserve
-this choice.
+this choice, while still enforcing that truly badly aligned code is formatted.
 
 Another example is aligning call parameters:
 
@@ -90,40 +114,6 @@ All of the alignment choices above are fine depending on the context where they 
 used, and Rufo will not destroy that choice. It will, however, keep things aligned
 so they look good.
 
-If Rufo does not change these things by default, what does it do? Well, it makes sure that:
-
-- code at the beginning of a line is correctly indented
-- array and hash elements are aligned
-- there are no spaces **before** commas
-- there are no more than one consecutive empty lines
-- methods are separated by an empty line
-- no trailing semicolons remain
-- no trailing whitespace remains
-- a trailing newline at the end of the file remains
-
-And of course it can be configured to do much more.
-Check the [Settings](https://github.com/ruby-formatter/rufo/wiki/Settings) section in the [Wiki](https://github.com/ruby-formatter/rufo/wiki) for more details.
-
-## Installation
-
-Add this line to your application's Gemfile:
-
-```ruby
-gem 'rufo'
-```
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install rufo
-    
-### Ruby support
-
-Rufo supports all Ruby versions >= 2.2.4.
-
 ## Usage
 
 ### Format files or directories
@@ -155,36 +145,10 @@ according to **Rufo**, and will exit with exit code 3.
 | `1` | Error. Either `Ripper` could not parse syntax or input file is missing |
 | `3` | Input changed. Formatted code differs from input |
 
-## Editor support
-
-- Atom: [rufo-atom](https://github.com/bmulvihill/rufo-atom) :construction:
-- Emacs [emacs-rufo](https://github.com/aleandros/emacs-rufo) :construction: or [rufo.el](https://github.com/danielma/rufo.el)
-- Sublime Text: [sublime-rufo](https://github.com/ruby-formatter/sublime-rufo)
-- Vim: [rufo-vim](https://github.com/splattael/rufo-vim)
-- Visual Studio Code: [rufo-vscode](https://marketplace.visualstudio.com/items?itemName=siliconsenthil.rufo-vscode) or [vscode-rufo](https://marketplace.visualstudio.com/items?itemName=mbessey.vscode-rufo)
-
-
-Did you write a plugin for your favorite editor? That's great! Let me know about it and
-I will list it here.
-
-### Tips for editor plugin implementors
-
-It is especially convenient if your code is automatically _formatted on save_.
-For example, surrounding a piece of code with `if ... end` will automatically indent
-the code when you save. Likewise, it will be automatically unindented should you remove it.
-
-For this to work best, the cursor position must be preserved, otherwise it becomes
-pretty annoying if the cursor is reset to the top of the editor.
-
-You should compute a diff between the old content and new content
-and apply the necessary changes. You can check out how this is done in the
-[Sublime Text plugin for Rufo](https://github.com/ruby-formatter/sublime-rufo):
-
-- [diff_match_patch.py](https://github.com/ruby-formatter/sublime-rufo/blob/master/diff_match_patch.py) contains the diff algorithm (you can port it to other languages or try to search for a similar algorithm online)
-- [rufo_format.py](https://github.com/ruby-formatter/sublime-rufo/blob/master/rufo_format.py#L46-L53) consumes the diff result and applies it chunk by chunk in the editor's view
 
 ## Configuration
 
+Rufo supports limited configuration.
 To configure Rufo, place a `.rufo` file in your project. Then when you format a file or a directory,
 Rufo will look for a `.rufo` file in that directory or parent directories and apply the configuration.
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ To configure Rufo, place a `.rufo` file in your project. Then when you format a 
 Rufo will look for a `.rufo` file in that directory or parent directories and apply the configuration.
 
 The `.rufo` file is a Ruby file that is evaluated in the context of the formatter.
-The available settings are listed [here](https://github.com/ruby-formatter/rufo/wiki/Settings).
+The available settings are listed [here](settings.md).
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ To configure Rufo, place a `.rufo` file in your project. Then when you format a 
 Rufo will look for a `.rufo` file in that directory or parent directories and apply the configuration.
 
 The `.rufo` file is a Ruby file that is evaluated in the context of the formatter.
-The available settings are listed [here](settings.md).
+The available settings are listed [here](docs/settings.md).
 
 ## How it works
 

--- a/docs/developing-rufo.md
+++ b/docs/developing-rufo.md
@@ -1,0 +1,17 @@
+# Rufo Development
+
+## Tips for editor plugin implementors
+
+It is especially convenient if your code is automatically _formatted on save_.
+For example, surrounding a piece of code with `if ... end` will automatically indent
+the code when you save. Likewise, it will be automatically unindented should you remove it.
+
+For this to work best, the cursor position must be preserved, otherwise it becomes
+pretty annoying if the cursor is reset to the top of the editor.
+
+You should compute a diff between the old content and new content
+and apply the necessary changes. You can check out how this is done in the
+[Sublime Text plugin for Rufo](https://github.com/ruby-formatter/sublime-rufo):
+
+- [diff_match_patch.py](https://github.com/ruby-formatter/sublime-rufo/blob/master/diff_match_patch.py) contains the diff algorithm (you can port it to other languages or try to search for a similar algorithm online)
+- [rufo_format.py](https://github.com/ruby-formatter/sublime-rufo/blob/master/rufo_format.py#L46-L53) consumes the diff result and applies it chunk by chunk in the editor's view

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,287 @@
+# Settings
+
+Rufo supports limited configuration.
+To configure Rufo, place a `.rufo` file in your project.
+Each configuration is a call with one argument. For example:
+
+```ruby
+# .rufo
+trailing_commas :never
+parens_in_def :dynamic
+```
+
+## :warning: Settings are going away! :warning:
+
+The settings described below will be removed from future versions of rufo :skull:
+
+See https://github.com/ruby-formatter/rufo/issues/2 for more context!
+
+## Table of contents
+
+- [align_case_when](#align_case_when)
+- [align_chained_calls](#align_chained_calls)
+- [double_newline_inside_type](#double_newline_inside_type)
+- [parens_in_def](#parens_in_def)
+- [spaces_around_binary](#spaces_around_binary)
+- [trailing_commas](#trailing_commas)
+
+### align_case_when
+
+Align successive case when?
+
+- `false`: (default) don't align case when (preserve existing code)
+- `true`: align successive case when
+
+Given this code:
+
+```ruby
+case exp
+when foo then 2
+when barbaz then 3
+end
+```
+
+With `true`, the formatter will change it to:
+
+```ruby
+case exp
+when foo    then 2
+when barbaz then 3
+end
+```
+
+With `false` it won't modify it.
+
+### align_chained_calls
+
+Align chained calls to the dot?
+
+- `false`: (default) don't align chained calls to the dot (preserve existing code)
+- `true`: align chained calls to the dot
+
+Given this code:
+
+```ruby
+foo.bar
+   .baz
+
+foo.bar
+  .baz
+```
+
+With `true`, the formatter will change it to:
+
+```ruby
+foo.bar
+   .baz
+
+foo.bar
+   .baz
+```
+
+With `false` it won't modify it.
+
+Note that with `false` it will keep it aligned to the dot if it's already like that.
+
+### double_newline_inside_type
+
+Allow an empty line inside a type declaration?
+
+- `:dynamic`: (default) allow at most one empty newline
+- `:no`: no empty newlines inside type declarations
+
+Given this code:
+
+```ruby
+class Foo
+
+  CONST = 1
+
+end
+
+class Bar
+  CONST = 2
+ end
+```
+
+With `:no` the formatter will change it to:
+
+```ruby
+class Foo
+  CONST = 1
+end
+
+class Bar
+  CONST = 2
+end
+```
+
+With `:dynamic` it won't modify it.
+
+### parens_in_def
+
+Use parentheses in defs?
+
+- `:yes`: (default) always use parentheses (add them if they are not there)
+- `:dynamic`: don't modify existing methods parentheses choice
+
+Given this code:
+
+```ruby
+def foo x, y
+end
+
+def bar(x, y)
+end
+```
+
+With `:yes` the formatter will change it to:
+
+```ruby
+def foo(x, y)
+end
+
+def bar(x, y)
+end
+```
+
+With `:dynamic` it won't modify it.
+
+### spaces_around_binary
+
+How to format spaces around a binary operator?
+
+- `:dynamic`: (default) allow any number of spaces around a binary operator
+- `:one`: at most one space around a binary operator
+
+Given this code:
+
+```ruby
+1+2
+1 +2
+1+ 2
+1  +  2
+```
+
+With `:one` the formatter will change it to:
+
+```ruby
+1+2
+1 + 2
+1+2
+1 + 2
+```
+
+Note that with `:one` the spaces are kept balanced: if there's no space
+before the operator, no space is kept after it. If there's a space
+before the operator, a space is added after it.
+
+With `:dynamic` it won't modify it.
+
+### trailing_commas
+
+Use trailing commas in array and hash literals, and keyword arguments?
+
+- `:always`: (default) always put a trailing comma
+- `:never`: never put a trailing comma
+
+Given this code:
+
+```ruby
+[
+  1,
+  2
+]
+
+[
+  1,
+  2,
+]
+
+{
+  foo: 1,
+  bar: 2
+}
+
+{
+  foo: 1,
+  bar: 2,
+}
+
+foo(
+  x: 1,
+  y: 2
+)
+
+foo(
+  x: 1,
+  y: 2,
+)
+```
+
+With `:always`, the formatter will change it to:
+
+```ruby
+[
+  1,
+  2,
+]
+
+[
+  1,
+  2,
+]
+
+{
+  foo: 1,
+  bar: 2,
+}
+
+{
+  foo: 1,
+  bar: 2,
+}
+
+foo(
+  x: 1,
+  y: 2,
+)
+
+foo(
+  x: 1,
+  y: 2,
+)
+```
+With `:never`, the formatter will change it to:
+
+```ruby
+[
+  1,
+  2
+]
+
+[
+  1,
+  2
+]
+
+{
+  foo: 1,
+  bar: 2
+}
+
+{
+  foo: 1,
+  bar: 2
+}
+
+foo(
+  x: 1,
+  y: 2
+)
+
+foo(
+  x: 1,
+  y: 2
+)
+```


### PR DESCRIPTION
In prep for #40 

i’m doing my best here to:
- move key points to encourage adoption to the top (what is rufo, how do i use it)
- move less important stuff out of the readme entirely. i went with version controller docs/ but could just as easily be a wiki page. personally i think its better practice to version control your docs along side your source code
- remove no longer relevant prose. a lot of the previous intro was invested in proving rufo's performance. while i appreciated that that is important, i believe rufo’s sell is the “one true format” stuff more than “we can format 5x faster than Rubocop”.
