### PR TITLE
Remove space around binary config

### DIFF
--- a/.rufo
+++ b/.rufo
@@ -1,4 +1,3 @@
-spaces_around_binary        :one
 double_newline_inside_type  :no
 trailing_commas             :always
 align_case_when             true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Config parsing and handling:
 The default for the following options has changed:
 - parens_in_def: ~~dynamic~~ > yes
 - last_has_comma: ~~dynamic~~ > always
-- spaces_around_binary: ~~dynamic~~ > one
 
 ### Removed
 The following configuration options have been **removed**, and replaced with non-configurable sane defaults, [per discussion](https://github.com/ruby-formatter/rufo/issues/2):
@@ -39,6 +38,7 @@ The following configuration options have been **removed**, and replaced with non
 - spaces_inside_array_bracket
 - spaces_inside_hash_brace
 - visibility_indent
+- spaces_around_binary
 
 ### Fixed
 - Fix crash in Ruby <=2.3.4, <=2.4.1 in the presence of certain squiggly doc (`<<~`) with multiple embedded expressions. The real fix here is to upgrade Ruby to >=2.3.5 / >=2.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Config parsing and handling:
 The default for the following options has changed:
 - parens_in_def: ~~dynamic~~ > yes
 - last_has_comma: ~~dynamic~~ > always
+- spaces_around_binary: ~~dynamic~~ > one
 
 ### Removed
 The following configuration options have been **removed**, and replaced with non-configurable sane defaults, [per discussion](https://github.com/ruby-formatter/rufo/issues/2):

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -811,8 +811,7 @@ class Rufo::Formatter
     else
       indent_after_space value, sticky: sticky,
                                 want_space: true,
-                                first_space: first_space,
-                                preserve_whitespace: false
+                                first_space: first_space
     end
   end
 
@@ -1820,10 +1819,8 @@ class Rufo::Formatter
       write " \\"
       write_line
       write_indent(next_indent)
-    elsif first_space && spaces_around_binary == :dynamic
-      write_space first_space[2]
     else
-      write_space if spaces_around_binary == :one
+      write_space
     end
 
     consume_op_or_keyword op
@@ -1835,14 +1832,9 @@ class Rufo::Formatter
                          want_space: needs_space,
                          needed_indent: needed_indent,
                          token_column: token_column,
-                         base_column: base_column,
-                         preserve_whitespace: spaces_around_binary == :dynamic
+                         base_column: base_column
     else
-      if spaces_around_binary == :one
-        write_space
-      elsif first_space
-        write_space first_space[2]
-      end
+      write_space
       visit right
     end
   end
@@ -3392,7 +3384,7 @@ class Rufo::Formatter
     @column += indent
   end
 
-  def indent_after_space(node, sticky: false, want_space: true, first_space: nil, needed_indent: next_indent, token_column: nil, base_column: nil, preserve_whitespace:)
+  def indent_after_space(node, sticky: false, want_space: true, first_space: nil, needed_indent: next_indent, token_column: nil, base_column: nil)
     first_space = current_token if space?
     skip_space
 
@@ -3416,11 +3408,7 @@ class Rufo::Formatter
       end
     else
       if want_space
-        if first_space && preserve_whitespace
-          write_space first_space[2]
-        else
-          write_space
-        end
+        write_space
       end
       if sticky
         indent(@column) do

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -1823,7 +1823,7 @@ class Rufo::Formatter
     elsif first_space && spaces_around_binary == :dynamic
       write_space first_space[2]
     else
-      write_space if needs_space
+      write_space if spaces_around_binary == :one
     end
 
     consume_op_or_keyword op
@@ -1839,7 +1839,7 @@ class Rufo::Formatter
                          preserve_whitespace: spaces_around_binary == :dynamic
     else
       if spaces_around_binary == :one
-        write " " if needs_space
+        write_space
       elsif first_space
         write_space first_space[2]
       end

--- a/lib/rufo/settings.rb
+++ b/lib/rufo/settings.rb
@@ -1,6 +1,6 @@
 module Rufo::Settings
   OPTIONS = {
-    spaces_around_binary: [:dynamic, :one],
+    spaces_around_binary: [:one, :dynamic],
     parens_in_def: [:yes, :dynamic],
     double_newline_inside_type: [:dynamic, :no],
     align_case_when: [false, true],

--- a/lib/rufo/settings.rb
+++ b/lib/rufo/settings.rb
@@ -1,6 +1,5 @@
 module Rufo::Settings
   OPTIONS = {
-    spaces_around_binary: [:one, :dynamic],
     parens_in_def: [:yes, :dynamic],
     double_newline_inside_type: [:dynamic, :no],
     align_case_when: [false, true],

--- a/spec/lib/rufo/formatter_source_specs/and_or_not.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/and_or_not.rb.spec
@@ -4,7 +4,7 @@
 
 #~# EXPECTED
 
-foo  and  bar
+foo and bar
 
 #~# ORIGINAL
 
@@ -12,7 +12,7 @@ foo  and  bar
 
 #~# EXPECTED
 
-foo  or  bar
+foo or bar
 
 #~# ORIGINAL
 

--- a/spec/lib/rufo/formatter_source_specs/binary_operators.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/binary_operators.rb.spec
@@ -1,40 +1,40 @@
-#~# ORIGINAL 
+#~# ORIGINAL
 
 1   +   2
 
 #~# EXPECTED
 
-1   +   2
+1 + 2
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 1+2
 
 #~# EXPECTED
 
-1+2
+1 + 2
 
-#~# ORIGINAL 
-
-1   +  
- 2
-
-#~# EXPECTED
+#~# ORIGINAL
 
 1   +
-  2
-
-#~# ORIGINAL 
-
-1   +  # hello 
  2
 
 #~# EXPECTED
 
-1   + # hello
+1 +
   2
 
-#~# ORIGINAL 
+#~# ORIGINAL
+
+1   +  # hello
+ 2
+
+#~# EXPECTED
+
+1 + # hello
+  2
+
+#~# ORIGINAL
 
 1 +
  2+
@@ -43,66 +43,66 @@
 #~# EXPECTED
 
 1 +
-  2+
+  2 +
   3
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 1  &&  2
 
 #~# EXPECTED
 
-1  &&  2
+1 && 2
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 1  ||  2
 
 #~# EXPECTED
 
-1  ||  2
+1 || 2
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 1*2
 
 #~# EXPECTED
 
-1*2
+1 * 2
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 1* 2
 
 #~# EXPECTED
 
-1* 2
+1 * 2
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 1 *2
 
 #~# EXPECTED
 
-1 *2
+1 * 2
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 1/2
 
 #~# EXPECTED
 
-1/2
+1 / 2
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 1**2
 
 #~# EXPECTED
 
-1**2
+1 ** 2
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 1 \
  + 2
@@ -112,7 +112,7 @@
 1 \
   + 2
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 a = 1 ||
 2
@@ -122,7 +122,7 @@ a = 1 ||
 a = 1 ||
     2
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 1 ||
 2

--- a/spec/lib/rufo/formatter_source_specs/spaces_around_binary.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/spaces_around_binary.rb.spec
@@ -1,14 +1,4 @@
 #~# ORIGINAL
-#~# spaces_around_binary: :dynamic
-
-1+2
-
-#~# EXPECTED
-
-1+2
-
-#~# ORIGINAL
-#~# spaces_around_binary: :one
 
 1+2
 
@@ -17,16 +7,14 @@
 1 + 2
 
 #~# ORIGINAL
-#~# spaces_around_binary: :dynamic
 
-1  +  2
+1+2
 
 #~# EXPECTED
 
-1  +  2
+1 + 2
 
 #~# ORIGINAL
-#~# spaces_around_binary: :one
 
 1  +  2
 
@@ -35,20 +23,17 @@
 1 + 2
 
 #~# ORIGINAL
-#~# spaces_around_binary: :dynamic
 
 1+  2
 
 #~# EXPECTED
 
-1+  2
+1 + 2
 
 #~# ORIGINAL
-#~# spaces_around_binary: :one
 
 1 +2
 
 #~# EXPECTED
 
 1 + 2
-

--- a/spec/lib/rufo/formatter_source_specs/spaces_around_binary.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/spaces_around_binary.rb.spec
@@ -14,7 +14,7 @@
 
 #~# EXPECTED
 
-1+2
+1 + 2
 
 #~# ORIGINAL
 #~# spaces_around_binary: :dynamic

--- a/spec/lib/rufo/settings_spec.rb
+++ b/spec/lib/rufo/settings_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Rufo::Settings do
 
     it 'outputs a warning for invalid config value' do
       exp_msg = "Invalid value for spaces_around_binary: :fake. Valid values " \
-      "are: :dynamic, :one\n"
+      "are: :one, :dynamic\n"
       expect {
         subject.init_settings(spaces_around_binary: :fake)
       }.to output(exp_msg).to_stderr

--- a/spec/lib/rufo/settings_spec.rb
+++ b/spec/lib/rufo/settings_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe Rufo::Settings do
   describe 'settings' do
     it 'does not output any warnings for expected settings' do
       expect {
-        subject.init_settings(spaces_around_binary: :dynamic)
+        subject.init_settings(parens_in_def: :yes)
       }.to output('').to_stderr
     end
 
     it 'outputs a warning for invalid config value' do
-      exp_msg = "Invalid value for spaces_around_binary: :fake. Valid values " \
-      "are: :one, :dynamic\n"
+      exp_msg = "Invalid value for parens_in_def: :fake. Valid values " \
+      "are: :yes, :dynamic\n"
       expect {
-        subject.init_settings(spaces_around_binary: :fake)
+        subject.init_settings(parens_in_def: :fake)
       }.to output(exp_msg).to_stderr
     end
 


### PR DESCRIPTION
There was some disagreement about this in #2 so I thought a PR might be the best way to decide what to do.

IMO the `dynamic` option is somewhat synonymous with "inconsistent" and this seems to go against the goals in #2. Thoughts?