### PR TITLE
Remove double newline inside type config

### DIFF
--- a/.rufo
+++ b/.rufo
@@ -1,5 +1,4 @@
 spaces_around_binary        :one
-double_newline_inside_type  :no
 trailing_commas             :always
 align_case_when             true
 align_chained_calls         true

--- a/.rufo
+++ b/.rufo
@@ -1,4 +1,3 @@
 spaces_around_binary        :one
-double_newline_inside_type  :no
 align_case_when             true
 align_chained_calls         true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Config parsing and handling:
 The default for the following options has changed:
 - parens_in_def: ~~dynamic~~ > yes
 - last_has_comma: ~~dynamic~~ > always
+- double_newline_inside_type: ~~dynamic~~ > no
 
 ### Removed
 The following configuration options have been **removed**, and replaced with non-configurable sane defaults, [per discussion](https://github.com/ruby-formatter/rufo/issues/2):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,6 @@ Config parsing and handling:
 The default for the following options has changed:
 - parens_in_def: ~~dynamic~~ > yes
 - last_has_comma: ~~dynamic~~ > always
-- double_newline_inside_type: ~~dynamic~~ > false
-
-The valid config for the following options has changed:
-- double_newline_inside_type: `false` and `true` are valid. `:dynamic` has been removed.
 
 ### Removed
 The following configuration options have been **removed**, and replaced with non-configurable sane defaults, [per discussion](https://github.com/ruby-formatter/rufo/issues/2):
@@ -42,6 +38,7 @@ The following configuration options have been **removed**, and replaced with non
 - spaces_inside_array_bracket
 - spaces_inside_hash_brace
 - visibility_indent
+- double_newline_inside_type
 
 ### Fixed
 - Fix crash in Ruby <=2.3.4, <=2.4.1 in the presence of certain squiggly doc (`<<~`) with multiple embedded expressions. The real fix here is to upgrade Ruby to >=2.3.5 / >=2.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The default for the following options has changed:
 - last_has_comma: ~~dynamic~~ > always
 - double_newline_inside_type: ~~dynamic~~ > no
 
+The valid config for the following options has changed:
+- double_newline_inside_type: `:no` and `:yes` are valid. `:dynamic` has been removed.
+
 ### Removed
 The following configuration options have been **removed**, and replaced with non-configurable sane defaults, [per discussion](https://github.com/ruby-formatter/rufo/issues/2):
 - align_assignments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ Config parsing and handling:
 The default for the following options has changed:
 - parens_in_def: ~~dynamic~~ > yes
 - last_has_comma: ~~dynamic~~ > always
-- double_newline_inside_type: ~~dynamic~~ > no
+- double_newline_inside_type: ~~dynamic~~ > false
 
 The valid config for the following options has changed:
-- double_newline_inside_type: `:no` and `:yes` are valid. `:dynamic` has been removed.
+- double_newline_inside_type: `false` and `true` are valid. `:dynamic` has been removed.
 
 ### Removed
 The following configuration options have been **removed**, and replaced with non-configurable sane defaults, [per discussion](https://github.com/ruby-formatter/rufo/issues/2):

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -6,7 +6,7 @@ Each configuration is a call with one argument. For example:
 
 ```ruby
 # .rufo
-trailing_commas :never
+trailing_commas false
 parens_in_def :dynamic
 ```
 
@@ -20,9 +20,7 @@ See https://github.com/ruby-formatter/rufo/issues/2 for more context!
 
 - [align_case_when](#align_case_when)
 - [align_chained_calls](#align_chained_calls)
-- [double_newline_inside_type](#double_newline_inside_type)
 - [parens_in_def](#parens_in_def)
-- [spaces_around_binary](#spaces_around_binary)
 - [trailing_commas](#trailing_commas)
 
 ### align_case_when
@@ -83,41 +81,6 @@ With `false` it won't modify it.
 
 Note that with `false` it will keep it aligned to the dot if it's already like that.
 
-### double_newline_inside_type
-
-Allow an empty line inside a type declaration?
-
-- `:dynamic`: (default) allow at most one empty newline
-- `:no`: no empty newlines inside type declarations
-
-Given this code:
-
-```ruby
-class Foo
-
-  CONST = 1
-
-end
-
-class Bar
-  CONST = 2
- end
-```
-
-With `:no` the formatter will change it to:
-
-```ruby
-class Foo
-  CONST = 1
-end
-
-class Bar
-  CONST = 2
-end
-```
-
-With `:dynamic` it won't modify it.
-
 ### parens_in_def
 
 Use parentheses in defs?
@@ -144,37 +107,6 @@ end
 def bar(x, y)
 end
 ```
-
-With `:dynamic` it won't modify it.
-
-### spaces_around_binary
-
-How to format spaces around a binary operator?
-
-- `:dynamic`: (default) allow any number of spaces around a binary operator
-- `:one`: at most one space around a binary operator
-
-Given this code:
-
-```ruby
-1+2
-1 +2
-1+ 2
-1  +  2
-```
-
-With `:one` the formatter will change it to:
-
-```ruby
-1+2
-1 + 2
-1+2
-1 + 2
-```
-
-Note that with `:one` the spaces are kept balanced: if there's no space
-before the operator, no space is kept after it. If there's a space
-before the operator, a space is added after it.
 
 With `:dynamic` it won't modify it.
 

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -1478,7 +1478,7 @@ class Rufo::Formatter
 
     line = @line
 
-    indent_body body, want_multiline: inside_type_body && double_newline_inside_type == :yes
+    indent_body body, want_multiline: inside_type_body && double_newline_inside_type
 
     while rescue_body
       # [:rescue, type, name, body, more_rescue]

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -3256,7 +3256,7 @@ class Rufo::Formatter
     end
   end
 
-  def indent_body(exps, force_multiline: false, want_multiline: false)
+  def indent_body(exps, force_multiline: false)
     first_space = skip_space
 
     has_semicolon = semicolon?
@@ -3313,7 +3313,7 @@ class Rufo::Formatter
     end
 
     indent do
-      consume_end_of_line(want_multiline: want_multiline)
+      consume_end_of_line(want_multiline: false)
     end
 
     if keyword?("then")
@@ -3327,7 +3327,7 @@ class Rufo::Formatter
       skip_space_or_newline
     else
       indent do
-        visit_exps exps, with_indent: true, want_trailing_multiline: want_multiline
+        visit_exps exps, with_indent: true
       end
       write_line unless @last_was_newline
     end

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -1478,7 +1478,7 @@ class Rufo::Formatter
 
     line = @line
 
-    indent_body body, want_multiline: inside_type_body && double_newline_inside_type
+    indent_body body
 
     while rescue_body
       # [:rescue, type, name, body, more_rescue]

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -1478,7 +1478,7 @@ class Rufo::Formatter
 
     line = @line
 
-    indent_body body, want_multiline: inside_type_body && double_newline_inside_type == :dynamic
+    indent_body body, want_multiline: inside_type_body && double_newline_inside_type == :yes
 
     while rescue_body
       # [:rescue, type, name, body, more_rescue]

--- a/lib/rufo/settings.rb
+++ b/lib/rufo/settings.rb
@@ -2,7 +2,6 @@ module Rufo::Settings
   OPTIONS = {
     spaces_around_binary: [:dynamic, :one],
     parens_in_def: [:yes, :dynamic],
-    double_newline_inside_type: [false, true],
     align_case_when: [false, true],
     align_chained_calls: [false, true],
     trailing_commas: [:always, :never],

--- a/lib/rufo/settings.rb
+++ b/lib/rufo/settings.rb
@@ -2,7 +2,7 @@ module Rufo::Settings
   OPTIONS = {
     spaces_around_binary: [:dynamic, :one],
     parens_in_def: [:yes, :dynamic],
-    double_newline_inside_type: [:no, :yes],
+    double_newline_inside_type: [false, true],
     align_case_when: [false, true],
     align_chained_calls: [false, true],
     trailing_commas: [:always, :never],

--- a/lib/rufo/settings.rb
+++ b/lib/rufo/settings.rb
@@ -2,7 +2,7 @@ module Rufo::Settings
   OPTIONS = {
     spaces_around_binary: [:dynamic, :one],
     parens_in_def: [:yes, :dynamic],
-    double_newline_inside_type: [:dynamic, :no],
+    double_newline_inside_type: [:no, :dynamic],
     align_case_when: [false, true],
     align_chained_calls: [false, true],
     trailing_commas: [:always, :never],

--- a/lib/rufo/settings.rb
+++ b/lib/rufo/settings.rb
@@ -2,7 +2,7 @@ module Rufo::Settings
   OPTIONS = {
     spaces_around_binary: [:dynamic, :one],
     parens_in_def: [:yes, :dynamic],
-    double_newline_inside_type: [:no, :dynamic],
+    double_newline_inside_type: [:no, :yes],
     align_case_when: [false, true],
     align_chained_calls: [false, true],
     trailing_commas: [:always, :never],

--- a/spec/lib/rufo/formatter_source_specs/double_newline_inside_type.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/double_newline_inside_type.rb.spec
@@ -13,7 +13,7 @@ class Foo
 end
 
 #~# ORIGINAL
-#~# double_newline_inside_type: :yes
+#~# double_newline_inside_type: true
 
 class Foo
 
@@ -30,7 +30,7 @@ class Foo
 end
 
 #~# ORIGINAL
-#~# double_newline_inside_type: :yes
+#~# double_newline_inside_type: true
 
 class Foo
 

--- a/spec/lib/rufo/formatter_source_specs/double_newline_inside_type.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/double_newline_inside_type.rb.spec
@@ -13,24 +13,6 @@ class Foo
 end
 
 #~# ORIGINAL
-#~# double_newline_inside_type: true
-
-class Foo
-
-1
-
-end
-
-#~# EXPECTED
-
-class Foo
-
-  1
-
-end
-
-#~# ORIGINAL
-#~# double_newline_inside_type: true
 
 class Foo
 
@@ -43,8 +25,6 @@ end
 #~# EXPECTED
 
 class Foo
-
   1
-
 end
 

--- a/spec/lib/rufo/formatter_source_specs/double_newline_inside_type.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/double_newline_inside_type.rb.spec
@@ -1,5 +1,4 @@
 #~# ORIGINAL
-#~# double_newline_inside_type: :no
 
 class Foo
 
@@ -14,11 +13,30 @@ class Foo
 end
 
 #~# ORIGINAL
-#~# double_newline_inside_type: :dynamic
+#~# double_newline_inside_type: :yes
 
 class Foo
 
 1
+
+end
+
+#~# EXPECTED
+
+class Foo
+
+  1
+
+end
+
+#~# ORIGINAL
+#~# double_newline_inside_type: :yes
+
+class Foo
+
+
+1
+
 
 end
 


### PR DESCRIPTION
A decision has not been made around this in #2 so thought that a PR might help!

Originally started out to just change the default to `:no` but then decided that this one might not be needed (see commits for these changes). Thoughts?