### PR TITLE
Change trailing comma config from symbols to booleans

### DIFF
--- a/.rufo
+++ b/.rufo
@@ -1,5 +1,4 @@
 spaces_around_binary        :one
 double_newline_inside_type  :no
-trailing_commas             :always
 align_case_when             true
 align_chained_calls         true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The default for the following options has changed:
 - parens_in_def: ~~dynamic~~ > yes
 - last_has_comma: ~~dynamic~~ > always
 
+Valid options for:
+- trailing_commas: `[:always, :never]` > `[true, false]`
+
 ### Removed
 The following configuration options have been **removed**, and replaced with non-configurable sane defaults, [per discussion](https://github.com/ruby-formatter/rufo/issues/2):
 - align_assignments

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -1033,7 +1033,7 @@ class Rufo::Formatter
 
       if found_comma
         if needs_trailing_newline
-          write "," if trailing_commas != :never && !block_arg
+          write "," if trailing_commas && !block_arg
 
           next_token
           indent(next_indent) do
@@ -1048,7 +1048,7 @@ class Rufo::Formatter
 
       if newline? || comment?
         if needs_trailing_newline
-          write "," if trailing_commas == :always && want_trailing_comma
+          write "," if trailing_commas && want_trailing_comma
 
           indent(next_indent) do
             consume_end_of_line
@@ -1059,7 +1059,7 @@ class Rufo::Formatter
         end
       else
         if needs_trailing_newline && !found_comma
-          write "," if trailing_commas == :always && want_trailing_comma
+          write "," if trailing_commas && want_trailing_comma
           consume_end_of_line
           write_indent
         end
@@ -2651,12 +2651,7 @@ class Rufo::Formatter
     end
 
     if needs_trailing_comma
-      case trailing_commas
-      when :always
-        write "," unless wrote_comma
-      when :never
-        # Nothing
-      end
+      write "," unless wrote_comma || !trailing_commas
 
       consume_end_of_line(first_space: first_space)
       write_indent

--- a/lib/rufo/settings.rb
+++ b/lib/rufo/settings.rb
@@ -5,7 +5,7 @@ module Rufo::Settings
     double_newline_inside_type: [:dynamic, :no],
     align_case_when: [false, true],
     align_chained_calls: [false, true],
-    trailing_commas: [:always, :never],
+    trailing_commas: [true, false],
   }
 
   attr_accessor *OPTIONS.keys

--- a/spec/lib/rufo/formatter_source_specs/trailing_commas.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/trailing_commas.rb.spec
@@ -1,5 +1,5 @@
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
 [
   1,
@@ -14,7 +14,7 @@
 ]
 
 #~# ORIGINAL
-#~# trailing_commas: :never
+#~# trailing_commas: false
 
 [
   1,
@@ -29,7 +29,7 @@
 ]
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
 [
   1,
@@ -44,7 +44,7 @@
 ]
 
 #~# ORIGINAL
-#~# trailing_commas: :never
+#~# trailing_commas: false
 
 [
   1,
@@ -59,7 +59,7 @@
 ]
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
 {
   foo: 1,
@@ -74,7 +74,7 @@
 }
 
 #~# ORIGINAL
-#~# trailing_commas: :never
+#~# trailing_commas: false
 
 {
   foo: 1,
@@ -89,7 +89,7 @@
 }
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
 {
   foo: 1,
@@ -104,7 +104,7 @@
 }
 
 #~# ORIGINAL
-#~# trailing_commas: :never
+#~# trailing_commas: false
 
 {
   foo: 1,
@@ -119,7 +119,7 @@
 }
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
 foo(
   one:   1,
@@ -136,7 +136,7 @@ foo(
 )
 
 #~# ORIGINAL
-#~# trailing_commas: :never
+#~# trailing_commas: false
 
 foo(
   one:   1,
@@ -153,7 +153,7 @@ foo(
 )
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
 foo(
   one:   1,
@@ -170,7 +170,7 @@ foo(
 )
 
 #~# ORIGINAL
-#~# trailing_commas: :never
+#~# trailing_commas: false
 
 foo(
   one:   1,
@@ -187,7 +187,7 @@ foo(
 )
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
 foo(
   one: 1)
@@ -199,7 +199,7 @@ foo(
 )
 
 #~# ORIGINAL
-#~# trailing_commas: :never
+#~# trailing_commas: false
 
 foo(
   one: 1)
@@ -211,7 +211,7 @@ foo(
 )
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
 foo(
   one: 1,)
@@ -223,7 +223,7 @@ foo(
 )
 
 #~# ORIGINAL
-#~# trailing_commas: :never
+#~# trailing_commas: false
 
 foo(
   one: 1,)
@@ -235,7 +235,7 @@ foo(
 )
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
  [
  1 , 2 ]
@@ -247,7 +247,7 @@ foo(
 ]
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
  [
  1 , 2, ]
@@ -259,7 +259,7 @@ foo(
 ]
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
  [
  1 , 2 ,
@@ -273,7 +273,7 @@ foo(
 ]
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
  [
  1 ,
@@ -287,7 +287,7 @@ foo(
 ]
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
  [  # comment
  1 ,
@@ -301,7 +301,7 @@ foo(
 ]
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
  [
  1 ,  # comment
@@ -315,7 +315,7 @@ foo(
 ]
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
  [ 1 ,
  2, 3,
@@ -328,7 +328,7 @@ foo(
  4]
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
  [ 1 ,
  2, 3,
@@ -341,7 +341,7 @@ foo(
  4]
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
  [ 1 ,
  2, 3,
@@ -355,7 +355,7 @@ foo(
  4]
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
  [ 1 ,
  2, 3,
@@ -370,7 +370,7 @@ foo(
 ]
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
  begin
  [
@@ -386,7 +386,7 @@ begin
 end
 
 #~# ORIGINAL
-#~# trailing_commas: :always
+#~# trailing_commas: true
 
  [
  1 # foo


### PR DESCRIPTION
Why: The symbols were effectively booleans anyway so this simplifies using and remembering these config options.

This was raised by @mjago [here](https://github.com/ruby-formatter/rufo/issues/2#issuecomment-341034889).