### PR TITLE
Add "Releasing a gem" section to docs/

### DIFF
--- a/docs/releasing-a-gem.md
+++ b/docs/releasing-a-gem.md
@@ -1,0 +1,18 @@
+# Releasing a gem
+
+1. Ensure that the tests pass and everything is working!
+
+2. Add missing release notes to `CHANGELOG.md`
+
+3. Bump version in
+  * `lib/rufo/version.rb`
+  * `CHANGELOG.md`
+  * `README.md`
+
+4. Commit version bump via
+  * `git commit -v "Release X.Y.Z"`
+
+5. Release gem to RubyGems via
+  * `rake release`
+
+6. :tada:


### PR DESCRIPTION
For me it's always hard to remember what to do when releasing a gem.

This PR describes the steps need to release a `rufo` gem.

Preview https://github.com/ruby-formatter/rufo/blob/readme-release/docs/releasing-a-gem.md

**Edit**: Moved to `docs/` as suggested by @gingermusketeer 