### PR TITLE
Adds failing spec when adding a space between nested array accessors

### DIFF
--- a/spec/lib/rufo/formatter_source_specs/array_access.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/array_access.rb.spec
@@ -92,3 +92,11 @@ foo[
   2, 3,
   4,
 ]
+
+#~# ORIGINAL
+
+x[a] [b]
+
+#~# EXPECTED
+
+x[a][b]


### PR DESCRIPTION
While trying out Rufo on the `graphql-ruby` project I got this error:
```
You've found a bug!
It happened while trying to format the file spec/graphql/query_spec.rb
Please report it to https://github.com/ruby-formatter/rufo/issues with code that triggers it

////ruby/gems/2.3.0/gems/rufo-0.1.0/lib/rufo/formatter.rb:3507:in `bug': Expected token on_lbracket, not on_sp at [[14, 49], :on_sp, " "] (Rufo::Bug)
```

I've reproduced the [failing line ](https://github.com/rmosolgo/graphql-ruby/blob/5ba66b23293e000198b2f9eded72969a7d69b181/spec/graphql/query_spec.rb#L89) in this PR's spec. I verified if this syntax actually works by doing:
```
irb(main):001:0> x = [[:hello]]
=> [[:hello]]
irb(main):002:0> x[0] [0]
=> :hello
```

Unfortunately, I don't have time to write the fix.