### PR TITLE
Add idempotency check to assert_source_specs()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added Idempotency check to source_specs/ tester.
 
 ## Fixed
 - Fix printing of extraneous trailing semicolons from inline classes, modules, methods (issue [#59](https://github.com/ruby-formatter/rufo/issues/59))

--- a/spec/lib/rufo/formatter_spec.rb
+++ b/spec/lib/rufo/formatter_spec.rb
@@ -43,6 +43,8 @@ def assert_source_specs(source_specs)
         formatted = described_class.format(test[:original], **test[:options])
         expected = test[:expected].rstrip + "\n"
         expect(formatted).to eq(expected)
+        idempotency_check = described_class.format(formatted, **test[:options])
+        expect(idempotency_check).to eq(formatted)
       end
     end
   end


### PR DESCRIPTION
This simply reformats the formatted result to ensure the original
formatting is idempotent, and helps find problems where the formatter
output oscillates between states, or for instance adds an unnecessary
indent per format.

A failure reports: _Failure/Error: expect(idempotency_check).to eq(formatted)_...
```shell
1) Rufo::Formatter formatter_source_specs/__END__.rb.spec formats unnamed test (line: 1)
     Failure/Error: expect(idempotency_check).to eq(formatted)    

       expected: "\n1\n\n__END__\nthis \n is \n still \n here\n"
            got: "\n1\n\n__END__\nthis \n is \n still \n here\n\\\n"

       (compared using ==)

       Diff: 
etc...
```

