### PR TITLE
Fix array literals against changes to Ruby HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix printing of extraneous trailing semicolons from inline classes, modules, methods (issue [#59](https://github.com/ruby-formatter/rufo/issues/59))
 - Fix unhandled white space between array getter/setters `x[0] [0]` (issue [#62](https://github.com/ruby-formatter/rufo/issues/62))
 - Fix comma printing for heredocs when inside a hash (issue [#61](https://github.com/ruby-formatter/rufo/issues/61))
+- Fix array literals against changes to Ruby 2.5.0
 
 ## [0.2.0] - 2017-11-13
 ### Changed

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -2166,10 +2166,10 @@ class Rufo::Formatter
     write current_token_value.strip
 
     # (pre 2.5.0) If there's a newline after `%w(`, write line and indent
-        if current_token_value.include?("\n") && elements # "%w[\n"
-          write_line
-          write_indent next_indent
-        end
+    if current_token_value.include?("\n") && elements # "%w[\n"
+      write_line
+      write_indent next_indent
+    end
 
     next_token
 

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -2165,13 +2165,25 @@ class Rufo::Formatter
     has_space = current_token_value.end_with?(" ")
     write current_token_value.strip
 
-    # If there's a newline after `%w(`, write line and indent
-    if current_token_value.include?("\n") && elements
-      write_line
-      write_indent(next_indent)
-    end
+    # (pre 2.5.0) If there's a newline after `%w(`, write line and indent
+        if current_token_value.include?("\n") && elements # "%w[\n"
+          write_line
+          write_indent next_indent
+        end
 
     next_token
+
+    # fix for 2.5.0 ripper change
+    if current_token_kind == :on_words_sep && elements && !elements.empty?
+      value = current_token_value
+      has_space = value.start_with?(' ')
+      if value.include?("\n") && elements # "\n "
+        write_line
+        write_indent next_indent
+      end
+      next_token
+      has_space = true if current_token_value.start_with?(' ')
+    end
 
     if elements && !elements.empty?
       write_space if has_space

--- a/spec/lib/rufo/formatter_source_specs/percent_array_literal.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/percent_array_literal.rb.spec
@@ -1,62 +1,70 @@
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %w(  ) 
+%w()
 
 #~# EXPECTED
 
 %w()
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %w(one) 
+ %w(  )
+
+#~# EXPECTED
+
+%w()
+
+#~# ORIGINAL
+
+ %w(one)
 
 #~# EXPECTED
 
 %w(one)
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %w( one ) 
+ %w( one )
 
 #~# EXPECTED
 
 %w( one )
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %w(one   two 
- three ) 
+ %w(one   two
+ three )
 
 #~# EXPECTED
 
 %w(one two
    three)
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %w( one   two 
- three ) 
+ %w( one   two
+ three )
 
 #~# EXPECTED
 
 %w( one two
     three )
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %w( 
- one ) 
+ %w(
+ one )
 
 #~# EXPECTED
 
 %w(
   one)
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %w( 
- one 
- ) 
+ %w(
+ one
+ )
 
 #~# EXPECTED
 
@@ -64,20 +72,20 @@
   one
 )
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %w[ one ] 
+ %w[ one ]
 
 #~# EXPECTED
 
 %w[ one ]
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- begin 
- %w( 
- one 
- ) 
+ begin
+ %w(
+ one
+ )
  end
 
 #~# EXPECTED
@@ -88,73 +96,73 @@ begin
   )
 end
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %i(  ) 
+ %i(  )
 
 #~# EXPECTED
 
 %i()
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %i( one ) 
+ %i( one )
 
 #~# EXPECTED
 
 %i( one )
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %i( one   two 
- three ) 
+ %i( one   two
+ three )
 
 #~# EXPECTED
 
 %i( one two
     three )
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %i[ one ] 
+ %i[ one ]
 
 #~# EXPECTED
 
 %i[ one ]
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %W( ) 
+ %W( )
 
 #~# EXPECTED
 
 %W()
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %W( one ) 
+ %W( one )
 
 #~# EXPECTED
 
 %W( one )
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %W( one  two ) 
+ %W( one  two )
 
 #~# EXPECTED
 
 %W( one two )
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %W( one  two #{ 1 } ) 
+ %W( one  two #{ 1 } )
 
 #~# EXPECTED
 
 %W( one two #{1} )
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
 %W(#{1}2)
 
@@ -162,17 +170,17 @@ end
 
 %W(#{1}2)
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %I( ) 
+ %I( )
 
 #~# EXPECTED
 
 %I()
 
-#~# ORIGINAL 
+#~# ORIGINAL
 
- %I( one  two #{ 1 } ) 
+ %I( one  two #{ 1 } )
 
 #~# EXPECTED
 


### PR DESCRIPTION
Ripper has been updated in 2.5.0-dev and this fix reflects
those changes
