### PR TITLE
Adds specs for multiple star operations in array

### DIFF
--- a/spec/lib/rufo/formatter_source_specs/array_literal.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/array_literal.rb.spec
@@ -269,3 +269,47 @@ x = [{
   1, *a,
   b,
 ]
+
+#~# ORIGINAL
+
+[*a, *b]
+
+#~# EXPECTED
+
+[*a, *b]
+
+#~# ORIGINAL
+
+[
+    *a,
+    *b,
+]
+
+#~# EXPECTED
+
+[
+  *a,
+  *b,
+]
+
+#~# ORIGINAL
+
+[*[a], *[b]]
+
+#~# EXPECTED
+
+[*[a], *[b]]
+
+#~# ORIGINAL
+
+[
+    *[a],
+    *[b],
+]
+
+#~# EXPECTED
+
+[
+  *[a],
+  *[b],
+]


### PR DESCRIPTION
#79 

This spec passes on master, but fails on new-formatter with:
```
  3) Rufo::Formatter formatter_source_specs/array_literal.rb.spec formats unnamed test (line: 349)
     Failure/Error: raise Rufo::Bug.new("#{msg} at #{current_token}")

     Rufo::Bug:
       Expected token on_op, not on_ignored_nl at [[3, 7], :on_ignored_nl, "\n", #<Ripper::Lexer::State: EXPR_BEG|EXPR_LABEL>]
```

and
```
  4) Rufo::Formatter formatter_source_specs/array_literal.rb.spec formats unnamed test (line: 363)
     Failure/Error: expect(formatted).to eq(expected)

       expected: "\n[*[a], *[b]]\n"
            got: "\n[\n  *{:type=>:align, :contents=>{:type=>:group, :contents=>{:type=>:concat, :parts=>[\"[\", {:typ...}]}]}]}}, {:type=>:line, :soft=>true}, \"]\"]}, :break=>false, :expanded_states=>nil}, :n=>0},\n]\n"

       (compared using ==)

       Diff:
       @@ -1,3 +1,6 @@

       -[*[a], *[b]]
       +[
       +  *{:type=>:align, :contents=>{:type=>:group, :contents=>{:type=>:concat, :parts=>["[", {:type=>:indent, :contents=>{:type=>:concat, :parts=>[{:type=>:concat, :parts=>[]}, {:type=>:line, :soft=>true}, {:type=>:concat, :parts=>[{:type=>:concat, :parts=>["a", {:type=>:if_break, :break_contents=>",", :flat_contents=>""}]}]}]}}, {:type=>:line, :soft=>true}, "]"]}, :break=>false, :expanded_states=>nil}, :n=>0},
       +  *{:type=>:align, :contents=>{:type=>:group, :contents=>{:type=>:concat, :parts=>["[", {:type=>:indent, :contents=>{:type=>:concat, :parts=>[{:type=>:concat, :parts=>[]}, {:type=>:line, :soft=>true}, {:type=>:concat, :parts=>[{:type=>:concat, :parts=>["b", {:type=>:if_break, :break_contents=>",", :flat_contents=>""}]}]}]}}, {:type=>:line, :soft=>true}, "]"]}, :break=>false, :expanded_states=>nil}, :n=>0},
       +]
```