### PR TITLE
Adds failing spec when there is a case in a lambda

### DIFF
--- a/spec/lib/rufo/formatter_source_specs/lambdas.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/lambdas.rb.spec
@@ -73,3 +73,21 @@ end
 #~# EXPECTED
 
 -> (x) { }
+
+#~# ORIGINAL
+
+a :b, lambda {
+  case a
+  when nil
+  else
+  end
+}
+
+#~# EXPECTED
+
+a :b, lambda {
+  case a
+  when nil
+  else
+  end
+}


### PR DESCRIPTION
Originally this code was a scope on a Rails model, something like:
```lang=ruby
class SomeModel
  scope :all_the_things, lambda {
    case some_attribute
    when nil
      'Nothing'
    else
      'Something'
    end
  }
end

```

I simplified the cause of the failure and verified it is real Ruby by running:
```
➜  rufo git:(when_in_scope) cat /tmp/fire.rb
def a(*)
end

a :b, lambda {
  case a
  when nil
  else
  end
}
➜  rufo git:(when_in_scope) ruby  /tmp/fire.rb
➜  rufo git:(when_in_scope)
```

When formatting this file I get:
```
NoMethodError: undefined method `[]' for nil:NilClass
  /Users/willian/src/hackerone/.bundle/gems/ruby/2.3.0/bundler/gems/rufo-7bb9e85fb91d/lib/rufo/formatter.rb:4018:in `block in adjust_other_alignments'
```