### PR TITLE
Remove ruby 2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.5.0
   - 2.4.2
   - 2.3.5
-  - 2.2.8
   - ruby-head
 matrix:
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Drop support for ruby 2.2
 - Set minimum required ruby version. As rufo is not tested on unsupported versions it may (and is known to) break code.
 
 ## [0.3.1] - 2018-04-12

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Unlike the best known Ruby formatter [RuboCop](https://github.com/bbatsov/ruboco
 
 RuboCop does much more than just format code though, so feel free to run them both!
 
-Rufo supports all Ruby versions >= 2.2.4, but works most reliably with >= 2.3.**5** / >= 2.4.**2**, due to a bug in Ruby's Ripper parser.
+Rufo supports all Ruby versions >= 2.3.**5** / >= 2.4.**2**, due to a bug in Ruby's Ripper parser.
 
 ## Installation
 

--- a/rufo.gemspec
+++ b/rufo.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '>= 2.2.4'
+  spec.required_ruby_version = '>= 2.3.5'
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Why: Ruby 2.2 is no longer supported by the ruby core team.

See https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/ for more info.
