### PR TITLE
Allow :bodystmt in lambda nodes to suit Ripper format in 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.3.1] - 2018-04-12
 
 ### Fixed
+- Allow :bodystmt in lambda nodes. Fixes a couple of broken tests in ruby-head (travis).
 - Fix `quote_style` config not being respected (issue [#95](https://github.com/ruby-formatter/rufo/issues/95)).
 
 ## [0.3.0] - 2018-03-24

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -2524,8 +2524,11 @@ class Rufo::Formatter
 
   def visit_lambda(node)
     # [:lambda, [:params, nil, nil, nil, nil, nil, nil, nil], [[:void_stmt]]]
+    # [:lambda, [:params, nil, nil, nil, nil, nil, nil, nil], [[:@int, "1", [2, 2]], [:@int, "2", [3, 2]]]]
+    # [:lambda, [:params, nil, nil, nil, nil, nil, nil, nil], [:bodystmt, [[:@int, "1", [2, 2]], [:@int, "2", [3, 2]]], nil, nil, nil]] (on 2.6.0)
     _, params, body = node
 
+    body = body[1] if body[0] == :bodystmt
     check :on_tlambda
     write "->"
     next_token


### PR DESCRIPTION
Fixes a couple of failing tests in Ruby-head on Travis (tests set to `allow-fail' so they tend to go by un-noticed.