### PR TITLE
Fix for new Ripper node :excessed_comma in block parsing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.3.1] - 2018-04-12
 
 ### Fixed
+- Fix for new Ripper node :excessed_comma in block parsing. Fixes some specs in ruby-head.
 - Fix `quote_style` config not being respected (issue [#95](https://github.com/ruby-formatter/rufo/issues/95)).
 
 ## [0.3.0] - 2018-03-24

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -2111,8 +2111,9 @@ class Rufo::Formatter
     end
 
     if rest_param
-      # check for trailing , |x, |
-      if rest_param == 0
+      # check for trailing , |x, | (may be [:excessed_comma] in 2.6.0)
+      case rest_param
+      when 0, [:excessed_comma]
         write_params_comma
       else
         # [:rest_param, [:@ident, "x", [1, 15]]]


### PR DESCRIPTION
Fixes a couple of specs in ruby-head (travis)