### PR TITLE
Fix bug for double colon operator in method definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Set minimum required ruby version. As rufo is not tested on unsupported versions it may (and is known to) break code.
 
+### Fixed
+- Fix bug for double colon operator in method definition (issue [#120](https://github.com/ruby-formatter/rufo/issues/120))
+
 ## [0.3.1] - 2018-04-12
 
 ### Fixed

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -2000,9 +2000,8 @@ class Rufo::Formatter
     visit receiver
     skip_space_or_newline
 
-    check :on_period
-    write "."
-    next_token
+    consume_call_dot
+
     skip_space_or_newline
 
     push_hash(node) do

--- a/spec/lib/rufo/formatter_source_specs/method_definition_with_receiver.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/method_definition_with_receiver.rb.spec
@@ -9,12 +9,30 @@ def foo.bar; end
 
 #~# ORIGINAL
 
+ def foo ::
+ bar; end
+
+#~# EXPECTED
+
+def foo::bar; end
+
+#~# ORIGINAL
+
  def self .
  bar; end
 
 #~# EXPECTED
 
 def self.bar; end
+
+#~# ORIGINAL
+
+ def self ::
+ bar; end
+
+#~# EXPECTED
+
+def self::bar; end
 
 #~# ORIGINAL multi_inline_definitions
 

--- a/spec/lib/rufo/formatter_source_specs/method_definition_with_receiver.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/method_definition_with_receiver.rb.spec
@@ -34,6 +34,18 @@ def self.bar; end
 
 def self::bar; end
 
+#~# ORIGINAL
+
+module Foo
+  def Foo ::
+bar; end; end
+
+#~# EXPECTED
+
+module Foo
+  def Foo::bar; end
+end
+
 #~# ORIGINAL multi_inline_definitions
 
 def foo(x); end; def bar(y); end


### PR DESCRIPTION
This fixes #120.