### PR TITLE
Start using RuboCop on the Rufo codebase

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,60 @@
+AllCops:
+  Exclude:
+    - "spec/**/*"
+  TargetRubyVersion: 2.3
+
+Layout:
+  Enabled: false
+
+Metrics:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/IfInsideElse:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/OneLineConditional:
+  Enabled: false
+
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+# https://github.com/ruby-formatter/rufo/pull/131#issuecomment-439686721
+Style/EmptyCaseCondition:
+  Enabled: false
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: false
+
+Lint/EmptyWhen:
+  Enabled: false
+
+# Lots of unused variables to tidy up.
+Lint/UselessAssignment:
+  Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in rufo.gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,7 @@
-guard :rspec, cmd: 'rspec' do
+# frozen_string_literal: true
+
+guard :rspec, cmd: "rspec" do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$}) { |m| "spec/lib/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb') { "spec" }
+  watch("spec/spec_helper.rb") { "spec" }
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "rufo"

--- a/exe/rufo
+++ b/exe/rufo
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require "rufo"
 
 Rufo::Command.run(ARGV)

--- a/lib/rufo/dot_file.rb
+++ b/lib/rufo/dot_file.rb
@@ -7,9 +7,7 @@ class Rufo::DotFile
 
   def get_config_in(dir)
     dot_rufo = find_in(dir)
-    if dot_rufo
-      return parse(dot_rufo)
-    end
+    return parse(dot_rufo) if dot_rufo
   end
 
   def find_in(dir)
@@ -30,7 +28,7 @@ class Rufo::DotFile
       elsif value == "false"
         value = false
       else
-        $stderr.puts "Unknown config value=#{value.inspect} for #{name.inspect}"
+        warn "Unknown config value=#{value.inspect} for #{name.inspect}"
         next
       end
       acc[name.to_sym] = value
@@ -40,9 +38,7 @@ class Rufo::DotFile
   def internal_find_in(dir)
     dir = File.expand_path(dir)
     file = File.join(dir, ".rufo")
-    if File.exist?(file)
-      return File.read(file)
-    end
+    return File.read(file) if File.exist?(file)
 
     parent_dir = File.dirname(dir)
     return if parent_dir == dir

--- a/lib/rufo/settings.rb
+++ b/lib/rufo/settings.rb
@@ -1,28 +1,30 @@
+# frozen_string_literal: true
+
 module Rufo::Settings
   OPTIONS = {
-    parens_in_def: [:yes, :dynamic],
+    parens_in_def: %i[yes dynamic],
     align_case_when: [false, true],
     align_chained_calls: [false, true],
     trailing_commas: [true, false],
-    quote_style: [:double, :single],
-  }
+    quote_style: %i[double single],
+  }.freeze
 
-  attr_accessor *OPTIONS.keys
+  attr_accessor(*OPTIONS.keys)
 
   def init_settings(options)
     OPTIONS.each do |name, valid_options|
       default = valid_options.first
       value = options.fetch(name, default)
       unless valid_options.include?(value)
-        $stderr.puts "Invalid value for #{name}: #{value.inspect}. Valid " \
-                     "values are: #{valid_options.map(&:inspect).join(", ")}"
+        warn "Invalid value for #{name}: #{value.inspect}. Valid " \
+             "values are: #{valid_options.map(&:inspect).join(", ")}"
         value = default
       end
-      self.public_send("#{name}=", value)
+      public_send("#{name}=", value)
     end
     diff = options.keys - OPTIONS.keys
     diff.each do |key|
-      $stderr.puts "Invalid config option=#{key}"
+      warn "Invalid config option=#{key}"
     end
   end
 end

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 desc "Run tasks on CI"
-task :ci => :spec do
+task ci: :spec do
   Rake::Task["rufo:check"].invoke("lib spec")
 end

--- a/rakelib/rufo.rake
+++ b/rakelib/rufo.rake
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 desc "Alias for `rake rufo:run`"
-task :rufo => ["rufo:run"]
+task rufo: ["rufo:run"]
 
 namespace :rufo do
   require "rufo"
@@ -11,12 +13,12 @@ namespace :rufo do
   end
 
   desc "Format Ruby code in current directory"
-  task :run, [:files_or_dirs] do |task, rake_args|
+  task :run, [:files_or_dirs] do |_task, rake_args|
     rufo_command(rake_args)
   end
 
   desc "Check that no formatting changes are produced"
-  task :check, [:files_or_dirs] do |task, rake_args|
+  task :check, [:files_or_dirs] do |_task, rake_args|
     rufo_command("--check", rake_args)
   end
 end

--- a/rufo.gemspec
+++ b/rufo.gemspec
@@ -1,5 +1,6 @@
-# coding: utf-8
-lib = File.expand_path("../lib", __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "rufo/version"
 
@@ -9,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Ary Borenszweig"]
   spec.email         = ["asterite@gmail.com"]
 
-  spec.summary       = %q{Ruby code formatter}
-  spec.description   = %q{Fast and unobtrusive Ruby code formatter}
+  spec.summary       = "Ruby code formatter"
+  spec.description   = "Fast and unobtrusive Ruby code formatter"
   spec.homepage      = "https://github.com/ruby-formatter/rufo"
   spec.license       = "MIT"
 
@@ -20,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '>= 2.3.5'
+  spec.required_ruby_version = ">= 2.3.5"
 
   spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "guard-rspec", "~> 4.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "guard-rspec", "~> 4.0"
 end


### PR DESCRIPTION
I added RuboCop as a dependency, and I set up a default `.rubocop_todo.yml` and `.rubocop.yml`. (There are currently 49 offenses to fix.)

I'd love to see the Rufo project using RuboCop, and vice versa.

EDIT: Actually [RuboCop crashes when used with the `--auto-correct` option](https://github.com/rubocop-hq/rubocop/issues/6489). (Similar issue to #130, because Rufo also breaks on the RuboCop codebase.)