### PR TITLE
Escape string interpolation inside single quotes when converting to double quotes

### DIFF
--- a/spec/lib/rufo/formatter_source_specs/string_literals.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/string_literals.rb.spec
@@ -38,6 +38,72 @@
 
 "hello #{1} foo"
 
+#~# ORIGINAL single_quote_percent_string_literal_1
+
+'hello #{1} foo'
+
+#~# EXPECTED
+
+"hello \#{1} foo"
+
+#~# ORIGINAL single_quote_percent_string_literal_2
+
+'hello \#{1} foo'
+
+#~# EXPECTED
+
+'hello \#{1} foo'
+
+#~# ORIGINAL single_quote_percent_string_literal_3
+
+'hello \ #{1} foo'
+
+#~# EXPECTED
+
+'hello \ #{1} foo'
+
+#~# ORIGINAL single_quote_percent_string_literal_4
+
+'hello #{
+1} foo'
+
+#~# EXPECTED
+
+"hello \#{
+1} foo"
+
+#~# ORIGINAL single_quote_percent_string_literal_5
+
+'hello #@foo foo'
+
+#~# EXPECTED
+
+"hello \#@foo foo"
+
+#~# ORIGINAL single_quote_percent_string_literal_6
+
+'hello \ #@foo foo'
+
+#~# EXPECTED
+
+'hello \ #@foo foo'
+
+#~# ORIGINAL single_quote_percent_string_literal_7
+
+'hello #$foo foo'
+
+#~# EXPECTED
+
+"hello \#$foo foo"
+
+#~# ORIGINAL single_quote_percent_string_literal_8
+
+'hello \ #$foo foo'
+
+#~# EXPECTED
+
+'hello \ #$foo foo'
+
 #~# ORIGINAL percent_string_literal_2
 
 "hello #{  1   } foo"


### PR DESCRIPTION
`'hello #{1} foo'` => `"hello \#{1} foo"`

Fixes a bug I encountered with the RuboCop codebase. See: #130