### PR TITLE
Fix string formatting for special strings

### DIFF
--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -638,6 +638,8 @@ class Rufo::Formatter
     return if string.include?("\\")
     # don't format strings that contain our quote character
     return if string.include?(quote_char)
+    return if string.include?('#{')
+    return if string.include?('#$')
     true
   end
 

--- a/spec/lib/rufo/formatter_source_specs/single_quotes.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/single_quotes.rb.spec
@@ -44,6 +44,15 @@
 "#{interpolation}"
 
 #~# ORIGINAL
+#~# quote_style: :double
+
+'#{interpolation}'
+
+#~# EXPECTED
+
+'#{interpolation}'
+
+#~# ORIGINAL
 #~# quote_style: :single
 
 "\0 \x7e \e \n \r \t \u1f680 \'"
@@ -51,6 +60,52 @@
 #~# EXPECTED
 
 "\0 \x7e \e \n \r \t \u1f680 \'"
+
+#~# ORIGINAL
+#~# quote_style: :double
+
+'\0 \x7e \e \n \r \t \u1f680 \''
+
+#~# EXPECTED
+
+'\0 \x7e \e \n \r \t \u1f680 \''
+
+#~# ORIGINAL
+#~# quote_style: :double
+
+'"'
+
+#~# EXPECTED
+
+'"'
+
+#~# ORIGINAL
+#~# quote_style: :double
+
+'#$foo'
+
+#~# EXPECTED
+
+'#$foo'
+
+#~# ORIGINAL
+#~# quote_style: :double
+
+'#$'
+
+#~# EXPECTED
+
+'#$'
+
+#~# ORIGINAL
+#~# quote_style: :double
+
+'#'
+
+#~# EXPECTED
+
+"#"
+
 
 #~# ORIGINAL
 #~# quote_style: :single


### PR DESCRIPTION
Why: Not all strings can be converted from single quotes to double quotes as the meaning changes.

This resolves #130 and is an alternative approach to #133.

<!--
  Thank you for contributing to rufo!
  Please remember to update the CHANGELOG with the contents of this PR.
-->
