### PR TITLE
Fixed Indentation for Squiggly Heredocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix bug: Rufo indents squiggly HEREDOC incorrectly causing bad formating (issue [136](https://github.com/ruby-formatter/rufo/issues/136))
 
 ### Fixed
 

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -245,25 +245,32 @@ class Rufo::Formatter
       if heredoc && tilde && broken_ripper_version?
         @squiggly_flag = true
       end
-      # For heredocs with tilde we sometimes need to align the contents
-      if heredoc && tilde && @last_was_newline
-        unless (current_token_value == "\n" ||
-                current_token_kind == :on_heredoc_end)
-          write_indent(next_indent)
-        end
-        skip_ignored_space
-        if current_token_kind == :on_tstring_content
-          check :on_tstring_content
-          consume_token_value(current_token_value)
-          next_token
-        end
+      looking_at_newline = current_token_kind == :on_tstring_content && current_token_value == "\n"
+      if heredoc && tilde && !@last_was_newline && looking_at_newline
+        check :on_tstring_content
+        consume_token_value(current_token_value)
+        next_token
       else
-        while (current_token_kind == :on_ignored_sp) ||
-              (current_token_kind == :on_tstring_content) ||
-              (current_token_kind == :on_embexpr_beg)
-          check current_token_kind
-          break if current_token_kind == :on_embexpr_beg
-          consume_token current_token_kind
+        # For heredocs with tilde we sometimes need to align the contents
+        if heredoc && tilde && @last_was_newline
+          unless (current_token_value == "\n" ||
+                  current_token_kind == :on_heredoc_end)
+            write_indent(next_indent)
+          end
+          skip_ignored_space
+          if current_token_kind == :on_tstring_content
+            check :on_tstring_content
+            consume_token_value(current_token_value)
+            next_token
+          end
+        else
+          while (current_token_kind == :on_ignored_sp) ||
+                (current_token_kind == :on_tstring_content) ||
+                (current_token_kind == :on_embexpr_beg)
+            check current_token_kind
+            break if current_token_kind == :on_embexpr_beg
+            consume_token current_token_kind
+          end
         end
       end
     when :string_content

--- a/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
@@ -247,3 +247,29 @@ EOF
 <<~EOF
   #{1}#{2}
 EOF
+
+#~# ORIGINAL heredoc_squiggly_extra_spaces_5
+<<~EOF
+  #{1}
+  #{2}
+EOF
+  
+#~# EXPECTED
+<<~EOF
+  #{1}
+  #{2}
+EOF
+
+#~# ORIGINAL heredoc_squiggly_extra_spaces_6
+<<~EOF
+ #{1}
+ #{2}
+EOF
+
+#~# EXPECTED
+<<~EOF
+  #{1}
+  #{2}
+EOF
+
+


### PR DESCRIPTION
Rufo indents squiggly HEREDOC incorrectly causing bad formating (issue [136](https://github.com/ruby-formatter/rufo/issues/136))

