### PR TITLE
Add rubocop config rufo to readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add rubocop-config-rufo to README.
 - Chore: Added ruby 2.6.0 to CI test runs.
 
 ## [0.4.1] - 2018-10-27

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Once the gem is installed, enable format on save integration in your editor of c
 If you're interested in developing your own plugin check out the [development docs](docs/developing-rufo.md). Did you already write a plugin? That's great! Let us know about it and
 we will list it here.
 
+## Rubocop support
+
+Rubocop is a linter tool, to make it work with rufo, you can use
+[rubocop-config-rufo](https://github.com/xinminlabs/rubocop-config-rufo) to turn off all rubocop cops that are unnecessary or might conflict with rufo.
+
 
 ## Unobtrusive by default
 


### PR DESCRIPTION
I just created [rubocop-config-rufo](https://github.com/xinminlabs/rubocop-config-rufo) to make rufo work with rubocop.