### PR TITLE
Allow bundler v2 to be used in development 

### DIFF
--- a/rufo.gemspec
+++ b/rufo.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.3.5'
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", ">= 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "guard-rspec", "~> 4.0"


### PR DESCRIPTION
Why: It is the default version with ruby 2.6 and the restriction is causing issues on CI.

See failures for #137.