### PR TITLE
Feature - Setup RuboCop for linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,14 @@
                             --out test_results/rspec.xml \
                             --format progress
     - run:
+        name: Run RuboCop
+        command: |
+          bundle exec rake rubocop
+    - run:
         name: Run Rufo
         command: |
           bundle exec rake rufo:run['lib spec']
+
     # Save test results for timing analysis
     - store_test_results:
         path: test_results
@@ -45,7 +50,7 @@
 
 version: 2
 jobs:
-  build-2-6-0:
+  build-2-6-1:
     <<: *dockerbuild
     docker:
       - image: circleci/ruby:2.6.1
@@ -81,7 +86,7 @@ workflows:
   version: 2
   test:
     jobs:
-      - build-2-6-0
+      - build-2-6-1
       - build-2-5-1
       - build-2-4-4
       - build-2-3-7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - "spec/**/*"
+    - "vendor/**/*"
   TargetRubyVersion: 2.3
 
 Layout:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,51 @@
+AllCops:
+  Exclude:
+    - "spec/**/*"
+  TargetRubyVersion: 2.3
+
+Layout:
+  Enabled: false
+
+Metrics:
+  Enabled: false
+
+Style:
+  Enabled: false
+
+# Configuration to look into removing:
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: false
+
+Lint/EmptyWhen:
+  Enabled: false
+
+Lint/UselessAssignment:
+  Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  Enabled: false
+
+Gemspec/OrderedDependencies:
+  Enabled: false
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Lint/AmbiguousOperator:
+  Enabled: false
+
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+
+Performance/UnfreezeString:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Naming/MethodName:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "rubocop/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new
 
 task :default => :spec

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -1,4 +1,5 @@
 desc "Run tasks on CI"
 task :ci => :spec do
+  Rake::Task["rubocop"].invoke
   Rake::Task["rufo:check"].invoke("lib spec")
 end

--- a/rakelib/ci.rake
+++ b/rakelib/ci.rake
@@ -1,5 +1,0 @@
-desc "Run tasks on CI"
-task :ci => :spec do
-  Rake::Task["rubocop"].invoke
-  Rake::Task["rufo:check"].invoke("lib spec")
-end

--- a/rufo.gemspec
+++ b/rufo.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "guard-rspec", "~> 4.0"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4.1"
+  spec.add_development_dependency "rubocop", "~> 0.63.1"
 end


### PR DESCRIPTION
This is a basic setup of [RuboCop](http://rubocop.readthedocs.io/) that does not try to resolve any linting issues with the Rufo codebase yet.

Purpose of this PR is to:
1. Setup RuboCop.
1. Integrate RuboCop into CI.
1. Identify an initial set of rules that are causing failures and should be addressed. 

I see the following being addressed in follow up PRs:
1. Resolving linting issues that have been disabled temporarily.
1. Documenting how to extend Rufo's RuboCop configuration for use in other codebases.

Closes #131 and #138.

