### PR TITLE
Fix bug: Rufo output doesn't satisfy rufo --check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix bug: Rufo output sometimes does not satisfy `rufo --check` (super-suboptimal fix, performance degradation almost certain)
+
 ### Added
 
 ## [0.5.0] - 2019-02-09

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -12,7 +12,17 @@ class Rufo::Formatter
   def self.format(code, **options)
     formatter = new(code, **options)
     formatter.format
-    formatter.result
+    previous_result = formatter.result
+    iterations = 1
+    loop do
+      formatter = new(formatter.result, **options)
+      formatter.format
+      current_result = formatter.result
+      return current_result if current_result == previous_result
+      previous_result = current_result
+      iterations += 1
+      raise "endless recursion suspected" if iterations > 3
+    end
   end
 
   def initialize(code, **options)

--- a/spec/lib/rufo/formatter_source_specs/hash_literal.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/hash_literal.rb.spec
@@ -134,3 +134,12 @@
 #~# EXPECTED
 
 { 1 => 2 }
+
+#~# ORIGINAL
+
+{ 1 => 2
+}
+
+#~# EXPECTED
+
+{ 1 => 2 }


### PR DESCRIPTION
I found this while working on #153.

It seems to be a bug I've run into previously, where the output of rufo run through `rufo --check` fails, and a second run of rufo triggers more changes. Last time I hit this I just ran rufo again and committed that, but while I'm here anyway, might as well try and get a fix pushed upstream

This is a very ugly fix for that just re-runs Rufo.format until the output stops changing (or 3 formats, to protect against infinite flapping between two states), but it seems overly heavy-handed.

I would love any suggestions on how this second bug might be addressed more efficiently