### PR TITLE
Ignore vendor directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@
     - run:
         name: Run Rufo
         command: |
-          bundle exec rake rufo:run['lib spec exe/rufo rakelib Rakefile rufo.gemspec']
+          bundle exec rake rufo:run
 
     # Save test results for timing analysis
     - store_test_results:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 ### Added
+- Ignore `vendor` directories from files to be checked. This allows rufo to be run without any arguments against a directory both locally and on common CI tools without needing any configuration.
 
 ## [0.5.1] - 2019-02-13
 

--- a/lib/rufo/file_finder.rb
+++ b/lib/rufo/file_finder.rb
@@ -22,6 +22,10 @@ class Rufo::FileFinder
     ".rake",
   ]
 
+  EXCLUDED_DIRS = [
+    "vendor",
+  ]
+
   def initialize(files_or_dirs)
     @files_or_dirs = files_or_dirs
   end
@@ -45,7 +49,7 @@ class Rufo::FileFinder
     Find.find(file_or_dir) do |path|
       basename = File.basename(path)
       if File.directory?(path)
-        Find.prune if basename == "vendor"
+        Find.prune if EXCLUDED_DIRS.include?(basename)
       else
         if EXTENSIONS.include?(File.extname(basename)) || FILENAMES.include?(basename)
           files << path

--- a/lib/rufo/file_finder.rb
+++ b/lib/rufo/file_finder.rb
@@ -1,3 +1,5 @@
+require "find"
+
 class Rufo::FileFinder
   include Enumerable
 
@@ -7,7 +9,18 @@ class Rufo::FileFinder
     "Rakefile",
     "rakefile.rb",
     "Rakefile.rb",
-  ].join(",")
+  ]
+
+  FILENAMES = [
+    "Gemfile",
+    *RAKEFILES,
+  ]
+
+  EXTENSIONS = [
+    ".rb",
+    ".gemspec",
+    ".rake",
+  ]
 
   def initialize(files_or_dirs)
     @files_or_dirs = files_or_dirs
@@ -28,9 +41,17 @@ class Rufo::FileFinder
   attr_reader :files_or_dirs
 
   def all_rb_files(file_or_dir)
-    Dir.glob(
-      File.join(file_or_dir, "**", "{*.rb,Gemfile,*.gemspec,#{RAKEFILES},*.rake}"),
-      File::FNM_EXTGLOB
-    ).select(&File.method(:file?))
+    files = []
+    Find.find(file_or_dir) do |path|
+      basename = File.basename(path)
+      if File.directory?(path)
+        Find.prune if basename == "vendor"
+      else
+        if EXTENSIONS.include?(File.extname(basename)) || FILENAMES.include?(basename)
+          files << path
+        end
+      end
+    end
+    files
   end
 end

--- a/spec/lib/rufo/file_finder_spec.rb
+++ b/spec/lib/rufo/file_finder_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe Rufo::FileFinder do
     end
   end
 
+  context "the directory contains vendor directory" do
+    let(:file_or_dir) { finder_fixture_path("only_vendor") }
+
+    it "ignores the vendor directory" do
+      expect(relative_paths(subject.to_a)).to match_array([])
+    end
+  end
+
   def relative_paths(paths, base = file_or_dir)
     paths.map { |(exists, path)| [exists, path.sub("#{base}/", "")] }
   end


### PR DESCRIPTION
Why: This is used for source code not maintained in the project that it is being run on so it does not make sense to include it. Also this is used commonly in CI tools for the installation of dependencies. Prior to this Rufo had to be configured to ignore this directory.
