### PR TITLE
Allow logging level to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Ignore `vendor` directories from files to be checked. This allows rufo to be run without any arguments against a directory both locally and on common CI tools without needing any configuration.
+- Allow logging level to be configured with `--loglevel[=LEVEL]`.
 
 ### Changed
 - Dropped support for ruby 2.3 as it is end of life.

--- a/lib/rufo.rb
+++ b/lib/rufo.rb
@@ -11,6 +11,7 @@ module Rufo
 end
 
 require_relative "rufo/command"
+require_relative "rufo/logger"
 require_relative "rufo/dot_file"
 require_relative "rufo/settings"
 require_relative "rufo/formatter"

--- a/lib/rufo/logger.rb
+++ b/lib/rufo/logger.rb
@@ -1,0 +1,39 @@
+module Rufo
+  class Logger
+    LEVELS = {
+      silent: 0,
+      error: 1,
+      warn: 2,
+      log: 3,
+      debug: 4,
+    }
+
+    def initialize(level)
+      @level = LEVELS.fetch(level)
+    end
+
+    def debug(*args)
+      $stdout.puts(*args) if should_output?(:debug)
+    end
+
+    def log(*args)
+      $stdout.puts(*args) if should_output?(:log)
+    end
+
+    def warn(*args)
+      $stderr.puts(*args) if should_output?(:warn)
+    end
+
+    def error(*args)
+      $stderr.puts(*args) if should_output?(:error)
+    end
+
+    private
+
+    attr_reader :level
+
+    def should_output?(level_to_check)
+      LEVELS.fetch(level_to_check) <= level
+    end
+  end
+end

--- a/spec/lib/rufo/logger_spec.rb
+++ b/spec/lib/rufo/logger_spec.rb
@@ -1,0 +1,83 @@
+require "spec_helper"
+
+RSpec.describe Rufo::Logger do
+  subject { described_class.new(level) }
+
+  let(:level) { :debug }
+
+  it "logs all levels" do
+    expect {
+      subject.log("a")
+      subject.debug("b")
+    }.to output("a\nb\n").to_stdout
+
+    expect {
+      subject.warn("c")
+      subject.error("d")
+    }.to output("c\nd\n").to_stderr
+  end
+
+  context "when set to log" do
+    let(:level) { :log }
+
+    it "logs all levels except debug" do
+      expect {
+        subject.log("a")
+        subject.debug("b")
+      }.to output("a\n").to_stdout
+
+      expect {
+        subject.warn("c")
+        subject.error("d")
+      }.to output("c\nd\n").to_stderr
+    end
+  end
+
+  context "when set to warn" do
+    let(:level) { :warn }
+
+    it "logs only warn and error levels" do
+      expect {
+        subject.log("a")
+        subject.debug("b")
+      }.to output("").to_stdout
+
+      expect {
+        subject.warn("c")
+        subject.error("d")
+      }.to output("c\nd\n").to_stderr
+    end
+  end
+
+  context "when set to error" do
+    let(:level) { :error }
+
+    it "logs only error levels" do
+      expect {
+        subject.log("a")
+        subject.debug("b")
+      }.to output("").to_stdout
+
+      expect {
+        subject.warn("c")
+        subject.error("d")
+      }.to output("d\n").to_stderr
+    end
+  end
+
+  context "when set to silent" do
+    let(:level) { :silent }
+
+    it "does not log anything" do
+      expect {
+        subject.log("a")
+        subject.debug("b")
+      }.to output("").to_stdout
+
+      expect {
+        subject.warn("c")
+        subject.error("d")
+      }.to output("").to_stderr
+    end
+  end
+end


### PR DESCRIPTION
Why: So that users can filter out information such as which files were formatted.

Closes #143.