### PR TITLE
Adds specs for various squiggly HEREDOC cases that crash the formatter

### DIFF
--- a/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
@@ -279,10 +279,6 @@ if true
 end
 
 #~# EXPECTED
-if true
-  <<~EOF
-  EOF
-end
 
 #~# ORIGINAL
 begin
@@ -293,12 +289,6 @@ begin
 end
 
 #~# EXPECTED
-begin
-  <<~EOF
-  EOF
-
-  true
-end
 
 #~# ORIGINAL
 -> {
@@ -307,7 +297,11 @@ end
 }
 
 #~# EXPECTED
--> {
-  x().x <<~EOF
+
+#~# ORIGINAL
+x do
+  x(<<-EOF).x
   EOF
-}
+end
+
+#~# EXPECTED

--- a/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
@@ -272,4 +272,15 @@ EOF
   #{2}
 EOF
 
+#~# ORIGINAL
+if true
+  <<~EOF
+  EOF
+end
+
+#~# EXPECTED
+if true
+  <<~EOF
+  EOF
+end
 

--- a/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
@@ -299,3 +299,15 @@ begin
 
   true
 end
+
+#~# ORIGINAL
+-> {
+  x().x <<~EOF
+  EOF
+}
+
+#~# EXPECTED
+-> {
+  x().x <<~EOF
+  EOF
+}

--- a/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/2.3/squiggly_heredoc.rb.spec
@@ -284,3 +284,18 @@ if true
   EOF
 end
 
+#~# ORIGINAL
+begin
+  <<~EOF
+  EOF
+
+  true
+end
+
+#~# EXPECTED
+begin
+  <<~EOF
+  EOF
+
+  true
+end


### PR DESCRIPTION
I stumbled upon a couple of code paths where the formatter fails on errors like:
```
Rufo::Bug: Expected token on_kw, not on_heredoc_end at [[3, 0], :on_heredoc_end, "  EOF\n"]
```
