### PR TITLE
Fix symbol literal formatting in ruby 2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
+- Fix bug: symbol literal like `:"foo"` in ruby 2.6.3 (issue [168](https://github.com/ruby-formatter/rufo/issues/168))
 
 ### Added
 

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -494,6 +494,8 @@ class Rufo::Formatter
     line_before_endline = nil
 
     exps.each_with_index do |exp, i|
+      next if exp == :string_content
+
       exp_kind = exp[0]
 
       # Skip voids to avoid extra indentation


### PR DESCRIPTION
Fixes #168 

<!--
  Thank you for contributing to rufo!
  Please remember to update the CHANGELOG with the contents of this PR.
-->
