### PR TITLE
Add ruby 2.6.3 to CI run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,14 @@
 
 version: 2
 jobs:
+  build-2-6-3:
+    <<: *dockerbuild
+    docker:
+      - image: circleci/ruby:2.6.3
+        environment:
+          BUNDLE_JOBS: "3"
+          BUNDLE_RETRY: "3"
+          BUNDLE_PATH: vendor/bundle
   build-2-6-1:
     <<: *dockerbuild
     docker:
@@ -78,6 +86,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - build-2-6-3
       - build-2-6-1
       - build-2-5-3
       - build-2-4-5


### PR DESCRIPTION
As pointed out in #168 2.6.3 has a different ripper output. Including this in the CI run should help us make sure Rufo works for both 2.6 versions.