### PR TITLE
Output detailed description of Syntax Error to log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Handle endless ranges in ruby 2.6
 
 ### Changed
+- Output detailed description of Syntax Error to log
 
 ### Added
 

--- a/lib/rufo.rb
+++ b/lib/rufo.rb
@@ -3,7 +3,14 @@
 module Rufo
   class Bug < StandardError; end
 
-  class SyntaxError < StandardError; end
+  class SyntaxError < StandardError
+    attr_reader :msg, :lineno
+
+    def initialize(msg, lineno)
+      @msg = msg
+      @lineno = lineno
+    end
+  end
 
   def self.format(code, **options)
     Formatter.format(code, **options)

--- a/lib/rufo/command.rb
+++ b/lib/rufo/command.rb
@@ -51,8 +51,8 @@ class Rufo::Command
     print(result) if !@want_check
 
     code == result ? CODE_OK : CODE_CHANGE
-  rescue Rufo::SyntaxError
-    logger.error("Error: the given text is not a valid ruby program (it has syntax errors)")
+  rescue Rufo::SyntaxError => e
+    logger.error("the given text line:#{e.lineno} #{e.msg}")
     CODE_ERROR
   rescue => ex
     logger.error("You've found a bug!")
@@ -96,10 +96,10 @@ class Rufo::Command
 
     begin
       result = format(code, @filename_for_dot_rufo || File.dirname(filename))
-    rescue Rufo::SyntaxError
+    rescue Rufo::SyntaxError => e
       # We ignore syntax errors as these might be template files
       # with .rb extension
-      logger.warn("Error: #{filename} has syntax errors")
+      logger.warn("#{filename}:#{e.lineno} #{e.msg}")
       return CODE_ERROR
     end
 
@@ -113,8 +113,8 @@ class Rufo::Command
 
       return CODE_CHANGE
     end
-  rescue Rufo::SyntaxError
-    logger.error("Error: the given text in #{filename} is not a valid ruby program (it has syntax errors)")
+  rescue Rufo::SyntaxError => e
+    logger.error("#{filename}:#{e.lineno} #{e.msg}")
     CODE_ERROR
   rescue => ex
     logger.error("You've found a bug!")

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -15,12 +15,9 @@ class Rufo::Formatter
 
   def initialize(code, **options)
     @code = code
+    check_syntax_error
     @tokens = Ripper.lex(code).reverse!
     @sexp = Ripper.sexp(code)
-
-    unless @sexp
-      raise ::Rufo::SyntaxError.new
-    end
 
     @indent = 0
     @line = 0
@@ -3869,5 +3866,15 @@ class Rufo::Formatter
     when :@label, :@int, :@ident, :@tstring_content, :@kw
       node[2][0]
     end
+  end
+
+  def check_syntax_error
+    ripper = Class.new(Ripper)
+    ["compile_error", "on_parse_error"].each do |method_name|
+      ripper.send(:define_method, method_name) do |msg|
+        raise ::Rufo::SyntaxError.new(msg, lineno)
+      end
+    end
+    ripper.new(@code).parse
   end
 end


### PR DESCRIPTION
<!--
  Thank you for contributing to rufo!
  Please remember to update the CHANGELOG with the contents of this PR.
-->



Purpose of this PR is to:
- Rufo's Syntax Error log to be detailed.

I suppose useful when working with editors especially.  
Can you consider it?

## Comparison
### before
when file input:
```
$ rufo foo.rb
Error: foo.rb has syntax errors
```

when STDIN:
```
$ cat foo.rb | rufo
Error: the given text is not a valid ruby program (it has syntax errors)
```

when editor extention:
![スクリーンショット 2019-11-29 18 52 11](https://user-images.githubusercontent.com/19568162/69860668-1607c580-12da-11ea-9be0-ad7700f9edb2.png)


### after
when file input:
```
$ rufo foo.rb
foo.rb:23 syntax error, unexpected tSTRING_BEG, expecting keyword_do or '{' or '('
```

when STDIN:
```
$ cat foo.rb | rufo
the given text line:23 syntax error, unexpected tSTRING_BEG, expecting keyword_do or '{' or '('
```

when editor extention:
![before](https://user-images.githubusercontent.com/19568162/69860587-efe22580-12d9-11ea-86f8-287d7283cf0d.png)

