### PR TITLE
Improve message when a syntax error occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Handle endless ranges in ruby 2.6
 
 ### Changed
+- Output detailed description of Syntax Error to log
 
 ### Added
 

--- a/lib/rufo.rb
+++ b/lib/rufo.rb
@@ -4,10 +4,10 @@ module Rufo
   class Bug < StandardError; end
 
   class SyntaxError < StandardError
-    attr_reader :msg, :lineno
+    attr_reader :lineno
 
-    def initialize(msg, lineno)
-      @msg = msg
+    def initialize(message, lineno)
+      super(message)
       @lineno = lineno
     end
   end
@@ -21,6 +21,7 @@ require_relative "rufo/command"
 require_relative "rufo/logger"
 require_relative "rufo/dot_file"
 require_relative "rufo/settings"
+require_relative "rufo/parser"
 require_relative "rufo/formatter"
 require_relative "rufo/version"
 require_relative "rufo/file_finder"

--- a/lib/rufo.rb
+++ b/lib/rufo.rb
@@ -3,7 +3,14 @@
 module Rufo
   class Bug < StandardError; end
 
-  class SyntaxError < StandardError; end
+  class SyntaxError < StandardError
+    attr_reader :msg, :lineno
+
+    def initialize(msg, lineno)
+      @msg = msg
+      @lineno = lineno
+    end
+  end
 
   def self.format(code, **options)
     Formatter.format(code, **options)

--- a/lib/rufo/command.rb
+++ b/lib/rufo/command.rb
@@ -52,7 +52,7 @@ class Rufo::Command
 
     code == result ? CODE_OK : CODE_CHANGE
   rescue Rufo::SyntaxError => e
-    logger.error("the given text line:#{e.lineno} #{e.msg}")
+    logger.error("STDIN is invalid code. Error on line:#{e.lineno} #{e.message}")
     CODE_ERROR
   rescue => ex
     logger.error("You've found a bug!")
@@ -99,7 +99,7 @@ class Rufo::Command
     rescue Rufo::SyntaxError => e
       # We ignore syntax errors as these might be template files
       # with .rb extension
-      logger.warn("#{filename}:#{e.lineno} #{e.msg}")
+      logger.warn("#{filename}:#{e.lineno} #{e.message}")
       return CODE_ERROR
     end
 
@@ -114,7 +114,7 @@ class Rufo::Command
       return CODE_CHANGE
     end
   rescue Rufo::SyntaxError => e
-    logger.error("#{filename}:#{e.lineno} #{e.msg}")
+    logger.error("#{filename}:#{e.lineno} #{e.message}")
     CODE_ERROR
   rescue => ex
     logger.error("You've found a bug!")

--- a/lib/rufo/command.rb
+++ b/lib/rufo/command.rb
@@ -51,8 +51,8 @@ class Rufo::Command
     print(result) if !@want_check
 
     code == result ? CODE_OK : CODE_CHANGE
-  rescue Rufo::SyntaxError
-    logger.error("Error: the given text is not a valid ruby program (it has syntax errors)")
+  rescue Rufo::SyntaxError => e
+    logger.error("the given text line:#{e.lineno} #{e.msg}")
     CODE_ERROR
   rescue => ex
     logger.error("You've found a bug!")
@@ -96,10 +96,10 @@ class Rufo::Command
 
     begin
       result = format(code, @filename_for_dot_rufo || File.dirname(filename))
-    rescue Rufo::SyntaxError
+    rescue Rufo::SyntaxError => e
       # We ignore syntax errors as these might be template files
       # with .rb extension
-      logger.warn("Error: #{filename} has syntax errors")
+      logger.warn("#{filename}:#{e.lineno} #{e.msg}")
       return CODE_ERROR
     end
 
@@ -113,8 +113,8 @@ class Rufo::Command
 
       return CODE_CHANGE
     end
-  rescue Rufo::SyntaxError
-    logger.error("Error: the given text in #{filename} is not a valid ruby program (it has syntax errors)")
+  rescue Rufo::SyntaxError => e
+    logger.error("#{filename}:#{e.lineno} #{e.msg}")
     CODE_ERROR
   rescue => ex
     logger.error("You've found a bug!")

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -15,12 +15,9 @@ class Rufo::Formatter
 
   def initialize(code, **options)
     @code = code
+    check_syntax_error
     @tokens = Ripper.lex(code).reverse!
     @sexp = Ripper.sexp(code)
-
-    unless @sexp
-      raise ::Rufo::SyntaxError.new
-    end
 
     @indent = 0
     @line = 0
@@ -3869,5 +3866,15 @@ class Rufo::Formatter
     when :@label, :@int, :@ident, :@tstring_content, :@kw
       node[2][0]
     end
+  end
+
+  def check_syntax_error
+    ripper = Class.new(Ripper)
+    ["compile_error", "on_parse_error"].each do |method_name|
+      ripper.send(:define_method, method_name) do |msg|
+        raise ::Rufo::SyntaxError.new(msg, lineno)
+      end
+    end
+    ripper.new(@code).parse
   end
 end

--- a/lib/rufo/parser.rb
+++ b/lib/rufo/parser.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "ripper"
+
+class Rufo::Parser < Ripper
+  def compile_error(msg)
+    raise ::Rufo::SyntaxError.new(msg, lineno)
+  end
+
+  def on_parse_error(msg)
+    raise ::Rufo::SyntaxError.new(msg, lineno)
+  end
+end

--- a/spec/lib/rufo/command_spec.rb
+++ b/spec/lib/rufo/command_spec.rb
@@ -153,6 +153,17 @@ RSpec.describe Rufo::Command do
         context "invalid code" do
           let(:code) { "not_valid(ruby" }
           it { is_expected.to terminate.with_code 1 }
+
+          it "outputs a useful message" do
+            message = "STDIN is invalid code. Error on line:1 syntax error, " \
+            "unexpected end-of-input, expecting ')'\n"
+            expect {
+              begin
+                subject.call
+              rescue SystemExit
+              end
+            }.to output(message).to_stderr
+          end
         end
       end
     end

--- a/spec/lib/rufo/parser_spec.rb
+++ b/spec/lib/rufo/parser_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+RSpec.describe Rufo::Parser do
+  subject { described_class }
+
+  it "parses valid code" do
+    subject.parse("a = 6")
+  end
+
+  context "code is invalid" do
+    let(:code) { "a do" }
+
+    it "raises an error with line number information" do
+      expect { subject.parse(code) }.to raise_error do |error|
+        expect(error).to be_a(Rufo::SyntaxError)
+        expect(error.lineno).to be(1)
+        expect(error.message).to eql("syntax error, unexpected end-of-input")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Why: So that you know which line the error is related to.

Builds on #193 and closes #193.