### PR TITLE
Add ruby 2.7 to test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,14 @@
 
 version: 2
 jobs:
+  build-2-7-0:
+    <<: *dockerbuild
+    docker:
+      - image: circleci/ruby:2.7.0
+        environment:
+          BUNDLE_JOBS: "3"
+          BUNDLE_RETRY: "3"
+          BUNDLE_PATH: /home/circleci/project/vendor/bundle
   build-2-6-3:
     <<: *dockerbuild
     docker:
@@ -92,6 +100,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - build-2-7-0
       - build-2-6-3
       - build-2-6-1
       - build-2-5-3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for rackup files
 - Settings for 'quote_style' to settings.md
 - Add support for ERB files
+- Add Ruby 2.7.0 to test runs on CI
 
 ## [0.7.0] - 2019-04-28
 


### PR DESCRIPTION
Why: So that it is included in all the test runs.

