### PR TITLE
Do not align method parameters with parenthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 ### Changed
+- Method parameters are now no longer aligned with the method parenthesis. For example:
+  - ```ruby
+    def foo(
+            param
+           )
+    end
+
+    # Becomes:
+
+    def foo(
+      param
+    )
+    end
+    ```
 
 ### Added
 

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -2031,6 +2031,7 @@ class Rufo::Formatter
       next_token
       skip_space
       skip_semicolons
+      broken_across_line = false
 
       if empty_params?(params)
         skip_space_or_newline
@@ -2041,8 +2042,8 @@ class Rufo::Formatter
         write "("
 
         if newline? || comment?
-          column = @column
-          indent(column) do
+          broken_across_line = true
+          indent(next_indent) do
             consume_end_of_line
             write_indent
             visit params
@@ -2056,6 +2057,10 @@ class Rufo::Formatter
         skip_space_or_newline
         consume_keyword("nil") if current_token[1] == :on_kw
         check :on_rparen
+        if broken_across_line
+          write_line
+          write_indent
+        end
         write ")"
         next_token
       end

--- a/spec/lib/rufo/formatter_source_specs/method_definition.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/method_definition.rb.spec
@@ -196,8 +196,27 @@ end
 
 #~# EXPECTED
 def foo(
-        x,
-        y)
+  x,
+  y
+)
+end
+
+#~# ORIGINAL
+class MultilineParams
+def foo(
+a: 1
+)
+a
+end
+end
+
+#~# EXPECTED
+class MultilineParams
+  def foo(
+    a: 1
+  )
+    a
+  end
 end
 
 #~# ORIGINAL


### PR DESCRIPTION
Why: Existing approach is not a common style. This should also minimize version control changes.

Resolves #83
```ruby
def foo(
        param
       )
end
```
Becomes:
```ruby
def foo(
  param
)
end
```