### PR TITLE
Handle escaped ERB template tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Added
+- Support for escaped ERB template tags. For example `<%%%%= format :name %>`.
 
 ## [0.10.0] - 2020-01-16
 

--- a/lib/rufo/erb_formatter.rb
+++ b/lib/rufo/erb_formatter.rb
@@ -8,7 +8,7 @@ class CustomScanner < ERB::Compiler::TrimScanner
   end
 
   def stags
-    ["<%=="] + super
+    ["<%==", "<%+={0,2}"] + super
   end
 
   def etags

--- a/spec/lib/rufo/erb_formatter_spec.rb
+++ b/spec/lib/rufo/erb_formatter_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe Rufo::ErbFormatter do
       expect(result).to eql("<%== link_to :a %>")
     end
 
+    it "handles escaped erb templates" do
+      result = subject.format("<%%= puts :foo %>")
+      expect(result).to eql("<%%= puts :foo %>")
+    end
+
+    it "handles escaped rails raw mode erb templates" do
+      result = subject.format("<%%== puts :foo %>")
+      expect(result).to eql("<%%== puts :foo %>")
+    end
+
     it "handles invalid code" do
       expect { subject.format("\n\n<% a+ %>") }.to raise_error { |error|
         expect(error).to be_a(Rufo::SyntaxError)


### PR DESCRIPTION
Why: Any number of '%' characters are allowed at the start of an ERB tag to indicate that it is escaped.

Resolves #224