### PR TITLE
Handle syntax errors not raised by ripper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - File.read default encode UTF-8
+- Handle case where the code is invalid but ripper does not raise an error.
 
 ### Changed
 

--- a/lib/rufo.rb
+++ b/lib/rufo.rb
@@ -2,6 +2,7 @@
 
 module Rufo
   class Bug < StandardError; end
+  class UnknownSyntaxError < StandardError; end
 
   class SyntaxError < StandardError
     attr_reader :lineno

--- a/lib/rufo/command.rb
+++ b/lib/rufo/command.rb
@@ -54,6 +54,9 @@ class Rufo::Command
   rescue Rufo::SyntaxError => e
     logger.error("STDIN is invalid code. Error on line:#{e.lineno} #{e.message}")
     CODE_ERROR
+  rescue Rufo::UnknownSyntaxError
+    logger.error("STDIN is invalid code. Try running the code for a better error.")
+    CODE_ERROR
   rescue => e
     logger.error("You've found a bug!")
     logger.error("Please report it to https://github.com/ruby-formatter/rufo/issues with code that triggers it\n")
@@ -121,6 +124,9 @@ class Rufo::Command
     end
   rescue Rufo::SyntaxError => e
     logger.error("#{filename}:#{e.lineno} #{e.message}")
+    CODE_ERROR
+  rescue Rufo::UnknownSyntaxError
+    logger.error("#{filename} is invalid code. Try running the code for a better error.")
     CODE_ERROR
   rescue => e
     logger.error("You've found a bug!")

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -21,7 +21,10 @@ class Rufo::Formatter
 
     # sexp being nil means that the code is not valid.
     # Parse the code so we get better error messages.
-    Rufo::Parser.parse(code) if @sexp.nil?
+    if @sexp.nil?
+      Rufo::Parser.parse(code)
+      raise Rufo::UnknownSyntaxError # Sometimes parsing does not raise an error
+    end
 
     @indent = 0
     @line = 0

--- a/spec/lib/rufo/command_spec.rb
+++ b/spec/lib/rufo/command_spec.rb
@@ -101,6 +101,11 @@ RSpec.describe Rufo::Command do
           let(:file) { "spec/fixtures/syntax_error" }
           it { is_expected.to terminate.with_code 1 }
         end
+
+        context "unknown syntax error" do
+          let(:file) { "spec/fixtures/unknown_syntax_error" }
+          it { is_expected.to terminate.with_code 1 }
+        end
       end
     end
 
@@ -169,6 +174,12 @@ RSpec.describe Rufo::Command do
           subject { -> { described_class.run(["--filename", "template.erb"]) } }
           let(:code) { "<%= foo %>" }
           it { is_expected.to terminate }
+        end
+
+        context "unknown syntax error" do
+          subject { -> { described_class.run([]) } }
+          let(:code) { "def foo; FOO = 1; end" }
+          it { is_expected.to terminate.with_code(1) }
         end
       end
     end

--- a/spec/lib/rufo/command_spec.rb
+++ b/spec/lib/rufo/command_spec.rb
@@ -106,6 +106,27 @@ RSpec.describe Rufo::Command do
           let(:file) { "spec/fixtures/unknown_syntax_error" }
           it { is_expected.to terminate.with_code 1 }
         end
+
+        context "rufo bug" do
+          let(:file) { "spec/fixtures/valid" }
+
+          before do
+            allow(Rufo::Formatter).to receive(:new).and_raise(StandardError)
+          end
+
+          it "outputs a useful message" do
+            message = "You've found a bug!\n" \
+            "It happened while trying to format the file .*\n" \
+            "Please report it to https://github.com/ruby-formatter/rufo/issues with code that " \
+            "triggers it\n"
+            expect {
+              begin
+                subject.call
+              rescue StandardError
+              end
+            }.to output(Regexp.new(message)).to_stderr
+          end
+        end
       end
     end
 
@@ -165,6 +186,26 @@ RSpec.describe Rufo::Command do
               begin
                 subject.call
               rescue SystemExit
+              end
+            }.to output(message).to_stderr
+          end
+        end
+
+        context "rufo bug" do
+          let(:code) { "some code" }
+
+          before do
+            allow(Rufo::Formatter).to receive(:new).and_raise(StandardError)
+          end
+
+          it "outputs a useful message" do
+            message = "You've found a bug!\nPlease report it to " \
+            "https://github.com/ruby-formatter/rufo/issues with code that " \
+            "triggers it\n"
+            expect {
+              begin
+                subject.call
+              rescue StandardError
               end
             }.to output(message).to_stderr
           end

--- a/spec/lib/rufo/formatter_spec.rb
+++ b/spec/lib/rufo/formatter_spec.rb
@@ -95,4 +95,12 @@ RSpec.describe Rufo::Formatter do
     assert_format "\n\n", ""
     assert_format "\n\n\n", ""
   end
+
+  describe "Syntax errors not handled by Ripper" do
+    it "raises an unknown syntax error" do
+      expect {
+        Rufo.format("def foo; FOO = 1; end")
+      }.to raise_error(Rufo::UnknownSyntaxError)
+    end
+  end
 end


### PR DESCRIPTION
Why: So that users know that the code is invalid.

Resolves https://github.com/ruby-formatter/rufo/issues/229