### PR TITLE
Fix Rakefile loading bug twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
+- Rakefile loading twice
 
 ### Changed
 

--- a/lib/rufo/file_finder.rb
+++ b/lib/rufo/file_finder.rb
@@ -6,7 +6,6 @@ class Rufo::FileFinder
 
   # Taken from https://github.com/ruby/rake/blob/f0a897e3fb557f64f5da59785b1a4464826f77b2/lib/rake/application.rb#L41
   RAKEFILES = [
-    "**/rakefile",
     "**/Rakefile",
     "**/rakefile.rb",
     "**/Rakefile.rb",


### PR DESCRIPTION
Loading Rakefile in duplicate and Rspec failed.

https://github.com/ruby-formatter/rufo/blob/master/spec/lib/rufo/file_finder_spec.rb#L46

The cause is that the Rakefile was read twice. `Rake :: FileList.new` uses` Dir.glob` internally. 
I think that `Dir.glob` may be due to the case insensitivity from Ruby 2.2.

https://github.com/ruby-formatter/rufo/blob/master/lib/rufo/file_finder.rb#L72

https://github.com/ruby/rake/blob/f0a897e3fb557f64f5da59785b1a4464826f77b2/lib/rake/file_list.rb#L408




