### PR TITLE
Properly format comma when a heredoc is passed as a call argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+## [0.13.0]
+
+### Fixed
+
+- Properly format trailing comma when a heredoc is passed as a call argument
+
+### Changed
+
+### Added
+
 ## [0.12.0] - 2020-03-08
 
 ### Fixed
+
 - File.read default encode UTF-8
 - Handle case where the code is invalid but ripper does not raise an error.
 - Removed implicit dependency on `rake`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-### Changed
-
-### Added
-
-## [0.13.0]
-
-### Fixed
-
-- Properly format trailing comma when a heredoc is passed as a call argument
+- Properly format comma when a heredoc is passed as a call argument
 
 ### Changed
 

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -1126,14 +1126,14 @@ class Rufo::Formatter
 
       found_comma = comma?
 
-      has_newline = false
+      heredoc_needs_newline = true
 
       if found_comma
         if needs_trailing_newline
           write "," if trailing_commas && !block_arg
 
           next_token
-          has_newline = newline?
+          heredoc_needs_newline = !newline?
           indent(next_indent) do
             consume_end_of_line
           end
@@ -1172,7 +1172,7 @@ class Rufo::Formatter
       call_info << @line
     end
 
-    if @last_was_heredoc && !has_newline
+    if @last_was_heredoc && heredoc_needs_newline
       write_line
     end
     consume_token :on_rparen

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -1174,6 +1174,7 @@ class Rufo::Formatter
 
     if @last_was_heredoc && heredoc_needs_newline
       write_line
+      write_indent
     end
     consume_token :on_rparen
   end

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -1126,11 +1126,14 @@ class Rufo::Formatter
 
       found_comma = comma?
 
+      has_newline = false
+
       if found_comma
         if needs_trailing_newline
           write "," if trailing_commas && !block_arg
 
           next_token
+          has_newline = newline?
           indent(next_indent) do
             consume_end_of_line
           end
@@ -1142,7 +1145,7 @@ class Rufo::Formatter
       end
 
       if newline? || comment?
-        if needs_trailing_newline
+        if needs_trailing_newline && !@last_was_heredoc
           write "," if trailing_commas && want_trailing_comma
 
           indent(next_indent) do
@@ -1154,7 +1157,7 @@ class Rufo::Formatter
         end
       else
         if needs_trailing_newline && !found_comma
-          write "," if trailing_commas && want_trailing_comma
+          write "," if trailing_commas && want_trailing_comma && !@last_was_heredoc
           consume_end_of_line
           write_indent
         end
@@ -1169,7 +1172,7 @@ class Rufo::Formatter
       call_info << @line
     end
 
-    if @last_was_heredoc
+    if @last_was_heredoc && !has_newline
       write_line
     end
     consume_token :on_rparen

--- a/spec/lib/rufo/formatter_source_specs/heredoc.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/heredoc.rb.spec
@@ -295,3 +295,59 @@ puts (<<-HELLO
   hello world
 HELLO
 )
+
+#~# ORIGINAL heredoc_as_last_arg_trailing_comma
+#~# trailing_commas: true
+
+foo(
+  another_arg: 4,
+  content: <<-EOF,
+    This is a heredoc
+  EOF
+)
+
+#~# EXPECTED
+foo(
+  another_arg: 4,
+  content: <<-EOF,
+    This is a heredoc
+  EOF
+)
+
+
+#~# ORIGINAL heredoc_as_first_arg_trailing_comma
+#~# trailing_commas: true
+
+foo(
+  content: <<-EOF,
+    This is a heredoc
+  EOF
+  another_arg: 4,
+)
+
+#~# EXPECTED
+foo(
+  content: <<-EOF,
+    This is a heredoc
+  EOF
+  another_arg: 4,
+)
+
+
+#~# ORIGINAL heredoc_as_last_arg_trailing_comma_without_comma
+#~# trailing_commas: true
+
+foo(
+  another_arg: 4,
+  content: <<-EOF
+    This is a heredoc
+  EOF
+)
+
+#~# EXPECTED
+foo(
+  another_arg: 4,
+  content: <<-EOF,
+    This is a heredoc
+  EOF
+)

--- a/spec/lib/rufo/formatter_source_specs/heredoc.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/heredoc.rb.spec
@@ -296,6 +296,25 @@ puts (<<-HELLO
 HELLO
 )
 
+#~# ORIGINAL heredoc_as_last_arg_trailing_comma_with_extra
+#~# trailing_commas: true
+
+foo(
+  another_arg: 4,
+  content: <<-EOF.trim,
+    This is a heredoc
+  EOF
+)
+
+#~# EXPECTED
+foo(
+  another_arg: 4,
+  content: <<-EOF.trim,
+    This is a heredoc
+  EOF
+)
+
+
 #~# ORIGINAL heredoc_as_last_arg_trailing_comma
 #~# trailing_commas: true
 
@@ -334,6 +353,24 @@ foo(
 )
 
 
+#~# ORIGINAL heredoc_as_last_arg_trailing_comma_without_comma_with_extra
+#~# trailing_commas: true
+
+foo(
+  another_arg: 4,
+  content: <<-EOF.trim
+    This is a heredoc
+  EOF
+)
+
+#~# EXPECTED
+foo(
+  another_arg: 4,
+  content: <<-EOF.trim
+    This is a heredoc
+  EOF
+)
+
 #~# ORIGINAL heredoc_as_last_arg_trailing_comma_without_comma
 #~# trailing_commas: true
 
@@ -347,7 +384,7 @@ foo(
 #~# EXPECTED
 foo(
   another_arg: 4,
-  content: <<-EOF,
+  content: <<-EOF
     This is a heredoc
   EOF
 )

--- a/spec/lib/rufo/formatter_source_specs/heredoc.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/heredoc.rb.spec
@@ -388,3 +388,31 @@ foo(
     This is a heredoc
   EOF
 )
+
+#~# ORIGINAL heredoc_with_indentation
+#~# trailing_commas: true
+
+foo do
+  bar(
+    output: <<-EOF,
+      Dragonlord Kolaghan
+      Kolaghan Aspirant
+      EOF
+    error: <<-EOF
+      Trying spelling "kolaghan" in addition to "kolagan"
+      EOF
+  )
+end
+
+#~# EXPECTED
+foo do
+  bar(
+    output: <<-EOF,
+      Dragonlord Kolaghan
+      Kolaghan Aspirant
+      EOF
+    error: <<-EOF
+      Trying spelling "kolaghan" in addition to "kolagan"
+      EOF
+  )
+end


### PR DESCRIPTION
I think this should fix #196 (at least it does for our codebase).

Important to note that this fix is agnostic to trailing commas, it will just leave them be (i.e. if enabled it won't add one if it isn't there nor remove one if it is there and trailing commas is disabled) - I wasn't 100% sure what I was doing and didn't want to go too far into the weeds to support that option. The main motivation behind this was to at least prevent Rufo from generating invalid Ruby.