### PR TITLE
Suggestion: Use clear example for excluding files by extension

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -284,5 +284,5 @@ Files can be excluded or included in formatting with rufo by specifying glob pat
 For example:
 ```
 includes [*.txt,*.text]
-excludes [*.rb]
+excludes [**/*.erb]
 ```


### PR DESCRIPTION
The current documentation lists `excludes [*.rb]` as example for excluding files. This creates the impression that you can ignore all Ruby Files (for example) by just specifying the extension. But actually a full glob pattern, e.g. `excludes [**/*.rb]`, is needed to do that. 
Since it is a more realistic use case, that not all source files are in the root project directory, I suggest replacing the current example for a complete glob pattern.