### PR TITLE
Correctly interpret case statements with multiple when clauses in ERB files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Properly format comma when a heredoc is passed as a call argument
+- Correctly interpret case statements with multiple when clauses in ERB files
 
 ### Changed
 

--- a/bin/verify-sample-code
+++ b/bin/verify-sample-code
@@ -8,6 +8,7 @@ repos = {
       "spec/rspec/core/formatters/snippet_extractor_spec.rb",
       "spec/rspec/core/metadata_spec.rb",
       "spec/rspec/core/formatters/html_formatter_spec.rb",
+      "spec/rspec/core/formatters_spec.rb",
     ].join(","),
   },
 }

--- a/lib/rufo/erb_formatter.rb
+++ b/lib/rufo/erb_formatter.rb
@@ -111,6 +111,7 @@ class Rufo::ErbFormatter
     return "begin", nil if Ripper.sexp("begin #{code_str}")
     return "begin\n", "\nend" if Ripper.sexp("begin\n#{code_str}\nend")
     return "if a\n", "\nend" if Ripper.sexp("if a\n#{code_str}\nend")
+    return "case a\n", "\nend" if Ripper.sexp("case a\n#{code_str}\nend")
     raise_syntax_error!(code_str)
   end
 

--- a/spec/lib/rufo/erb_formatter_spec.rb
+++ b/spec/lib/rufo/erb_formatter_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe Rufo::ErbFormatter do
       expect(result).to eql("<% if a %>\na\n<% elsif b %>\n<% end %>")
     end
 
+    it "handles case statements" do
+      result = subject.format("<% case a when a %>\na\n<% when b %>\n<% end %>")
+      expect(result).to eql("<% case a\n  when a %>\na\n<% when b %>\n<% end %>")
+    end
+
     it "handles multiline statements" do
       result = subject.format("<% link_to :a,\n:b %>")
       expect(result).to eql("<% link_to :a,\n          :b %>")


### PR DESCRIPTION
Basically a duplicate of the logic for `if` statements, now for `case` statements too!

Noticed this while working on a page which rendered correctly, but rufo claimed:
>STDIN is invalid code. Error on line:109 syntax error, unexpected `when'