### PR TITLE
Do not exit rake process

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require "rubocop/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
 
-task :default => :spec
+task :default => ["rufo:check", :spec]

--- a/lib/rufo/command.rb
+++ b/lib/rufo/command.rb
@@ -7,6 +7,11 @@ class Rufo::Command
   CODE_ERROR = 1
   CODE_CHANGE = 3
 
+  def self.run_and_return(argv)
+    want_check, exit_code, filename_for_dot_rufo, loglevel = parse_options(argv)
+    new(want_check, exit_code, filename_for_dot_rufo, loglevel).run_and_return(argv)
+  end
+
   def self.run(argv)
     want_check, exit_code, filename_for_dot_rufo, loglevel = parse_options(argv)
     new(want_check, exit_code, filename_for_dot_rufo, loglevel).run(argv)
@@ -33,13 +38,17 @@ class Rufo::Command
     end
   end
 
-  def run(argv)
+  def run_and_return(argv)
     status_code = if argv.empty?
         format_stdin
       else
         format_args argv
       end
-    exit exit_code(status_code)
+    exit_code(status_code)
+  end
+
+  def run(argv)
+    exit run_and_return(argv)
   end
 
   def format_stdin

--- a/rakelib/rufo.rake
+++ b/rakelib/rufo.rake
@@ -7,7 +7,8 @@ namespace :rufo do
   def rufo_command(*switches, rake_args)
     files_or_dirs = rake_args[:files_or_dirs] || "."
     args = switches + files_or_dirs.split(" ")
-    Rufo::Command.run(args)
+    result = Rufo::Command.run_and_return(args)
+    abort("Rufo failed with #{result}") unless result == 0
   end
 
   desc "Format Ruby code in current directory"


### PR DESCRIPTION
Rufo ships with a rake task

https://github.com/ruby-formatter/rufo/blob/master/rakelib/rufo.rake

which calls `Rufo::Command.run(args)`. Unfortunately, this method calls `Kernel.exit` at the very end which causes the Rake task to exit. This does not allow running other tasks when everything went well (e.g. rufo, rubocop, tests).