### PR TITLE
Bug/deeper blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Correctly interpret erb scriptlets with more than one control-flow/block statement
+
 ### Changed
 
 ### Added

--- a/bin/verify-sample-code
+++ b/bin/verify-sample-code
@@ -9,6 +9,8 @@ repos = {
       "spec/rspec/core/metadata_spec.rb",
       "spec/rspec/core/formatters/html_formatter_spec.rb",
       "spec/rspec/core/formatters_spec.rb",
+      "spec/rspec/core/formatters/documentation_formatter_spec.rb",
+      "spec/rspec/core/formatters/progress_formatter_spec.rb"
     ].join(","),
   },
 }

--- a/lib/rufo/erb_formatter.rb
+++ b/lib/rufo/erb_formatter.rb
@@ -129,7 +129,9 @@ class Rufo::ErbFormatter
     keywords = Ripper.lex("#{code_str}").filter { |lex_token| lex_token[1] == :on_kw }
     lexical_tokens = keywords.filter { |lex_token| lex_token[2] != "when" }.map { |lex_token| lex_token[3].to_s }
     state_tally = lexical_tokens.group_by(&:itself).transform_values(&:count)
-    depth = (state_tally["BEG"] || 0) - (state_tally["END"] || 0)
+    beg_token = state_tally["BEG"] || state_tally["EXPR_BEG"] || 0
+    end_token = state_tally["END"] || state_tally["EXPR_END"] || 0
+    depth = beg_token - end_token
 
     if depth > 0
       affix = format_affix("end", depth.abs, :suffix)


### PR DESCRIPTION
Allows ERB templates with nested `if`/`do` blocks, and the like, to be correctly interpreted.

Closes #266 and the incorrect syntax error failure.