### PR TITLE
Add: Support partial argument forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Support for partial argument forwarding. (issue [268](https://github.com/ruby-formatter/rufo/issues/268))
+
 ## [0.13.0] - 2021-05-07
 
 ### Fixed

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -2143,6 +2143,7 @@ class Rufo::Formatter
       when 0, [:excessed_comma]
         write_params_comma
       when [:args_forward]
+        write_params_comma if needs_comma
         consume_op "..."
       else
         # [:rest_param, [:@ident, "x", [1, 15]]]

--- a/spec/lib/rufo/formatter_source_specs/3.0/method_definition.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/3.0/method_definition.rb.spec
@@ -1,0 +1,9 @@
+#~# ORIGINAL  partial_forward_args
+def foo(a,    ...)
+  p(...)
+end
+
+#~# EXPECTED
+def foo(a, ...)
+  p(...)
+end

--- a/spec/lib/rufo/formatter_source_specs/method_definition.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/method_definition.rb.spec
@@ -257,6 +257,24 @@ end
 def foo(**)
 end
 
+#~# ORIGINAL  argument_forwarding
+
+def foo( ... )
+end
+
+#~# EXPECTED
+def foo(...)
+end
+
+#~# ORIGINAL  partial_argument_forwarding
+
+def foo(a,  ... )
+end
+
+#~# EXPECTED
+def foo(a, ...)
+end
+
 #~# ORIGINAL
 
 def `(cmd)
@@ -343,3 +361,4 @@ def a;1 end;def b;2 end;def c;3 end # comment
 def a; 1 end
 def b; 2 end
 def c; 3 end # comment
+

--- a/spec/lib/rufo/formatter_source_specs/method_definition.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/method_definition.rb.spec
@@ -257,24 +257,6 @@ end
 def foo(**)
 end
 
-#~# ORIGINAL  argument_forwarding
-
-def foo( ... )
-end
-
-#~# EXPECTED
-def foo(...)
-end
-
-#~# ORIGINAL  partial_argument_forwarding
-
-def foo(a,  ... )
-end
-
-#~# EXPECTED
-def foo(a, ...)
-end
-
 #~# ORIGINAL
 
 def `(cmd)

--- a/spec/lib/rufo/formatter_spec.rb
+++ b/spec/lib/rufo/formatter_spec.rb
@@ -87,6 +87,12 @@ RSpec.describe Rufo::Formatter do
     end
   end
 
+  if VERSION >= Gem::Version.new("3.0")
+    Dir[File.join(FILE_PATH, "/formatter_source_specs/3.0/*")].each do |source_specs|
+      assert_source_specs(source_specs) if File.file?(source_specs)
+    end
+  end
+
   # Empty
   describe "empty" do
     assert_format "", ""


### PR DESCRIPTION
Support partial argument forwarding.

```ruby
def func(x,...)
  nil
end
```
will be formatted to:
```ruby
def func(x, ...)
  nil
end
```

closes #268