### PR TITLE
Fix: Fix "includes all the rake files" test

### DIFF
--- a/spec/lib/rufo/file_finder_spec.rb
+++ b/spec/lib/rufo/file_finder_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Rufo::FileFinder do
-  subject { described_class.new([file_or_dir], includes: includes, excludes: excludes) }
+  subject { described_class.new([file_or_dir], includes: includes, excludes: excludes).uniq }
   let(:includes) { [] }
   let(:excludes) { [] }
 


### PR DESCRIPTION
In some enviroment, the test fails because file list contains same file.
I didn't put changelog because it changes only test.