### PR TITLE
Add valueless hash support for >= ruby 3.1

### DIFF
--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -2399,7 +2399,15 @@ class Rufo::Formatter
       consume_space
     end
 
-    visit value
+    if value.nil?
+      if RUBY_VERSION.to_f >= 3.1
+        # skip
+      else
+        bug "Valueless hashes are not allowed in ruby #{RUBY_VERSION}"
+      end
+    else
+      visit value
+    end
   end
 
   def visit_splat_inside_hash(node)

--- a/spec/lib/rufo/formatter_source_specs/3.1/valueless_hash.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/3.1/valueless_hash.rb.spec
@@ -1,0 +1,11 @@
+#~# ORIGINAL format_valueless_hash
+{a:     }
+
+#~# EXPECTED
+{ a: }
+
+#~# ORIGINAL format_mixed_hash
+{a:  , b: 5   }
+
+#~# EXPECTED
+{ a: , b: 5 }

--- a/spec/lib/rufo/formatter_spec.rb
+++ b/spec/lib/rufo/formatter_spec.rb
@@ -93,6 +93,12 @@ RSpec.describe Rufo::Formatter do
     end
   end
 
+  if VERSION >= Gem::Version.new("3.1")
+    Dir[File.join(FILE_PATH, "/formatter_source_specs/3.1/*")].each do |source_specs|
+      assert_source_specs(source_specs) if File.file?(source_specs)
+    end
+  end
+
   # Empty
   describe "empty" do
     assert_format "", ""


### PR DESCRIPTION
I would like to add support for valueless hashes

```ruby
a, b = 0, 1
c = { a:, b:, c: 2 }
```

because currently these are reported as bugs (`unexpected node:  at [[45, 18], :on_comma, ",", BEG|LABEL] at [[45, 18], :on_comma, ",", BEG|LABEL] (Rufo::Bug)`).

This PR is pretty simple so far - just adds a `nil?` check for value, but there's perhaps a bit more which could be done in terms of spacing:

- there is always a space between the colon and next comma (`{ a: , ... }`)
  - but perhaps there's a decision to be made as to which of `{a: , ...}` and `{a:, ...}` is preferred
- for a hash with a single value, it ends with a double space (`{ a:[\s\s]}`)

But I have a feeling it could be a fair bit more complex to look into these? If anyone has any thoughts or suggestions then please let me know!
