### PR TITLE
Fix test failures with ruby 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,14 @@
 
 version: 2
 jobs:
+  build-3-1-3:
+    <<: *dockerbuild
+    docker:
+      - image: cimg/ruby:3.1.3
+        environment:
+          BUNDLE_JOBS: "3"
+          BUNDLE_RETRY: "3"
+          BUNDLE_PATH: /home/circleci/project/vendor/bundle
   build-3-0-1:
     <<: *dockerbuild
     docker:
@@ -95,6 +103,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - build-3-1-3
       - build-3-0-1
       - build-2-7-3
       - build-2-6-7


### PR DESCRIPTION
The output of `Ripper.sexp` for `forward args` and `endless method` code has changed between Ruby 3.0 and 3.1.

```
$ cat <<EOS >code
def foo(...)
  p(...)
end
EOS

$ rbenv local 3.0.4; ruby -r ripper -e 'pp Ripper.sexp(File.read("code"))' >sexp_3_0.txt
$ rbenv local 3.1.3; ruby -r ripper -e 'pp Ripper.sexp(File.read("code"))' >sexp_3_1.txt
$ diff -u sexp_3_0.txt sexp_3_1.txt
--- sexp_3_0.txt        2023-01-12 22:10:48.039398792 +0900
+++ sexp_3_1.txt        2023-01-12 22:10:38.959447786 +0900
@@ -1,7 +1,7 @@
 [:program,
  [[:def,
    [:@ident, "foo", [1, 4]],
-   [:paren, [:params, nil, nil, [:args_forward], nil, nil, nil, nil]],
+   [:paren, [:params, nil, nil, nil, nil, nil, [:args_forward], :&]],
    [:bodystmt,
     [[:method_add_arg,
       [:fcall, [:@ident, "p", [2, 2]]],
```

```
$ cat <<EOS >code2
def foo( a,     b) = "a"
EOS

$ rbenv local 3.0.4; ruby -r ripper -e 'pp Ripper.sexp(File.read("code2"))' >sexp2_3_0.txt
$ rbenv local 3.1.3; ruby -r ripper -e 'pp Ripper.sexp(File.read("code2"))' >sexp2_3_1.txt
$ diff -u sexp2_3_0.txt sexp2_3_1.txt
--- sexp2_3_0.txt       2023-01-12 22:42:21.737961677 +0900
+++ sexp2_3_1.txt       2023-01-12 22:42:27.557831378 +0900
@@ -10,4 +10,8 @@
      nil,
      nil,
      nil]],
-   [:string_literal, [:string_content, [:@tstring_content, "a", [1, 22]]]]]]]
+   [:bodystmt,
+    [:string_literal, [:string_content, [:@tstring_content, "a", [1, 22]]]],
+    nil,
+    nil,
+    nil]]]]
```

In this pullreq has fixed `Rufo::Formatter` to work fine for each versions.