### PR TITLE
Add support anonymous rest and rest keyword arguments forwarding for ruby 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Support for anonymous block argument forwarding
 - Support for valueless hash literals and keyword arguments
+- Support for anonymous rest and rest keyword arguments forwarding
 
 ## [0.14.0] - 2023-01-25
 

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -1528,7 +1528,10 @@ class Rufo::Formatter
     write_indent(base_column) if needs_indent
     consume_op "*"
     skip_space_or_newline
-    visit star
+    # The name of splat argument might be omitted.
+    if star
+      visit star
+    end
 
     if post_args && !post_args.empty?
       write_params_comma
@@ -2413,7 +2416,11 @@ class Rufo::Formatter
     # [:assoc_splat, exp]
     consume_op "**"
     skip_space_or_newline
-    visit node[1]
+    exp = node[1]
+    # The name of kwargs might be omitted.
+    if exp
+      visit exp
+    end
   end
 
   def visit_range(node, inclusive)

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -1528,7 +1528,7 @@ class Rufo::Formatter
     write_indent(base_column) if needs_indent
     consume_op "*"
     skip_space_or_newline
-    # The name of splat argument might be omitted.
+    # The name of rest arguments might be omitted.
     if star
       visit star
     end
@@ -2417,7 +2417,7 @@ class Rufo::Formatter
     consume_op "**"
     skip_space_or_newline
     exp = node[1]
-    # The name of kwargs might be omitted.
+    # The name of rest kwargs might be omitted.
     if exp
       visit exp
     end

--- a/spec/lib/rufo/formatter_source_specs/3.2/method_definition.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/3.2/method_definition.rb.spec
@@ -1,4 +1,4 @@
-#~# ORIGINAL  anonymous_splat_forwarding
+#~# ORIGINAL  anonymous_rest_args_forwarding
 def foo(    * )
   p(*  )
 end
@@ -18,7 +18,7 @@ def foo(**)
   p(**)
 end
 
-#~# ORIGINAL  anonymous_splat_and_kwargs_forwarding
+#~# ORIGINAL  anonymous_rest_and_kwargs_forwarding
 def foo( * , ** )
   p( * , ** )
 end

--- a/spec/lib/rufo/formatter_source_specs/3.2/method_definition.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/3.2/method_definition.rb.spec
@@ -1,0 +1,29 @@
+#~# ORIGINAL  anonymous_splat_forwarding
+def foo(    * )
+  p(*  )
+end
+
+#~# EXPECTED
+def foo(*)
+  p(*)
+end
+
+#~# ORIGINAL  anonymous_kwargs_forwarding
+def foo(    ** )
+  p( **  )
+end
+
+#~# EXPECTED
+def foo(**)
+  p(**)
+end
+
+#~# ORIGINAL  anonymous_splat_and_kwargs_forwarding
+def foo( * , ** )
+  p( * , ** )
+end
+
+#~# EXPECTED
+def foo(*, **)
+  p(*, **)
+end

--- a/spec/lib/rufo/formatter_spec.rb
+++ b/spec/lib/rufo/formatter_spec.rb
@@ -89,6 +89,12 @@ RSpec.describe Rufo::Formatter do
     end
   end
 
+  if VERSION >= Gem::Version.new("3.2")
+    Dir[File.join(FILE_PATH, "/formatter_source_specs/3.2/*")].each do |source_specs|
+      assert_source_specs(source_specs) if File.file?(source_specs)
+    end
+  end
+
   # Empty
   describe "empty" do
     assert_format "", ""


### PR DESCRIPTION
<!--
  Thank you for contributing to rufo!
  Please remember to update the CHANGELOG with the contents of this PR.
-->
