### PR TITLE
chore: add mixed option for quote_style

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -227,6 +227,7 @@ Use the specified quotation marks.
 
 - `:double`: (default) use doublequotations unless one or more escaped double-quotations are included
 - `:single`: use single quotations unless one or more interpolations `#{}` or escaped single quotations are included
+- `:mixed`: use mixed quotations if you don't want to change quotes
 
 This does not affect `%q()` (single), `%Q()` (double), or quotation marks within heredocs.
 
@@ -277,6 +278,8 @@ code = <<CODE
   'single'
 CODE
 ```
+
+With `:mixed`, the formatter will keep lines as is
 
 ### Includes and excludes
 Files can be excluded or included in formatting with rufo by specifying glob patterns for the `includes` or `excludes` configuration options. Multiple patterns are separated by a comma.

--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -636,6 +636,7 @@ class Rufo::Formatter
 
   # should we format this string according to :quote_style?
   def should_format_string?(string)
+    return if quote_style == :mixed
     # don't format %q or %Q
     return unless current_token_value == "'" || current_token_value == '"'
     # don't format strings containing slashes

--- a/lib/rufo/settings.rb
+++ b/lib/rufo/settings.rb
@@ -4,7 +4,7 @@ module Rufo::Settings
     align_case_when: [false, true],
     align_chained_calls: [false, true],
     trailing_commas: [true, false],
-    quote_style: [:double, :single],
+    quote_style: [:double, :single, :mixed],
     includes: nil,
     excludes: nil,
   }

--- a/spec/lib/rufo/formatter_source_specs/mixed_quotes.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/mixed_quotes.rb.spec
@@ -1,0 +1,69 @@
+#~# ORIGINAL
+#~# quote_style: :mixed
+
+'a great string'
+"a great string"
+
+#~# EXPECTED
+'a great string'
+"a great string"
+
+#~# ORIGINAL
+#~# quote_style: :mixed
+
+'🚀'
+"🚀"
+
+#~# EXPECTED
+'🚀'
+"🚀"
+
+#~# ORIGINAL
+#~# quote_style: :mixed
+
+''
+""
+
+#~# EXPECTED
+''
+""
+
+#~# ORIGINAL
+#~# quote_style: :mixed
+
+'import \"quotes\"'
+
+#~# EXPECTED
+'import \"quotes\"'
+
+#~# ORIGINAL
+#~# quote_style: :mixed
+
+"#{interpolation}"
+
+#~# EXPECTED
+"#{interpolation}"
+
+#~# ORIGINAL
+#~# quote_style: :mixed
+
+"\0 \x7e \e \n \r \t \u1f680 \'"
+
+#~# EXPECTED
+"\0 \x7e \e \n \r \t \u1f680 \'"
+
+#~# ORIGINAL
+#~# quote_style: :mixed
+
+%q(single)
+
+#~# EXPECTED
+%q(single)
+
+#~# ORIGINAL
+#~# quote_style: :mixed
+
+%Q(double)
+
+#~# EXPECTED
+%Q(double)


### PR DESCRIPTION
Sometimes when we are working in a legacy code formatting a string changing its quote style is not something we really want to because it makes a PR review harder as a lot of modifications may be made.

With this option a developer can choose if that modification is needed or not

issue: https://github.com/ruby-formatter/rufo/issues/258

<!--
  Thank you for contributing to rufo!
  Please remember to update the CHANGELOG with the contents of this PR.
-->
