### PR TITLE
Fix CI

### DIFF
--- a/bin/verify-sample-code
+++ b/bin/verify-sample-code
@@ -1,9 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 repos = {
-  "lostisland/faraday" => {
-    "--format" => "progress",
-  },
+  "rspec/rspec-expectations" => {},
+  "rspec/rspec-mocks" => {},
 }
 
 def run_command(cmd, allowed_statuses: [0])


### PR DESCRIPTION
CI failed with ruby 2.7 because faraday requires ruby >= 3.0

<!--
  Thank you for contributing to rufo!
  Please remember to update the CHANGELOG with the contents of this PR.
-->
