### PR TITLE
Fix dropped method receiver after comment-in-parens (#357)

### DIFF
--- a/lib/rufo/formatter.rb
+++ b/lib/rufo/formatter.rb
@@ -3405,9 +3405,8 @@ class Rufo::Formatter
         if current_token_value.end_with?("\n")
           write_space
           write current_token_value.rstrip
-          write "\n"
+          write_line
           write_indent(next_indent)
-          @column = next_indent
         else
           write current_token_value
         end

--- a/spec/lib/rufo/formatter_source_specs/junk_drawer.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/junk_drawer.rb.spec
@@ -51,3 +51,22 @@ end
 
 def foo
 end
+
+#~# ORIGINAL issue 357 receiver preserved after comment in parens
+a=(#X
+1)
+
+[STDOUT].each{ |elem| elem.puts [
+    2
+  ]
+}
+
+#~# EXPECTED
+a = ( #X
+  1)
+
+[STDOUT].each { |elem|
+  elem.puts [
+    2,
+  ]
+}


### PR DESCRIPTION
Fixes #357 — rufo deleted method receivers in some block bodies, producing invalid Ruby.

- `skip_space_or_newline` wrote a trailing-newline comment via `write "\n"`, which doesn't advance `@line`; stale `@line` then caused `dedent_calls` to trim leading chars off an unrelated later line, dropping the receiver.
- Switch to `write_line` so `@line`/`@column`/`@last_was_newline` stay consistent; manual `@column = next_indent` is no longer needed.
- Regression spec added in `junk_drawer.rb.spec` mirroring the reproducer in #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)